### PR TITLE
fix: config.replace tests

### DIFF
--- a/test/interface-tests.spec.js
+++ b/test/interface-tests.spec.js
@@ -45,15 +45,7 @@ function executeTests (commonFactory) {
 
   tests.bootstrap(commonFactory)
 
-  tests.config(commonFactory, {
-    skip: [
-      // config.replace
-      {
-        name: 'replace',
-        reason: 'FIXME https://github.com/ipfs/js-kubo-rpc-client/issues/97'
-      }
-    ]
-  })
+  tests.config(commonFactory)
 
   tests.dag(commonFactory)
 


### PR DESCRIPTION
Closes #97.

I simply added a function that cleans up the returned configuration from Kubo. When replacing the configuration, Kubo fills  all the missing fields with null values.