### PR TITLE
feat: [multiformats pt 1] Removing Deprecated Package

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,6 @@
     "p-retry": "^5.1.1",
     "p-timeout": "^4.1.0",
     "pako": "^2.0.4",
-    "peer-id": "^0.16.0",
     "readable-stream": "^4.2.0",
     "sinon": "^14.0.1",
     "typedoc": "^0.23.10"

--- a/test/interface-tests/src/name-pubsub/cancel.js
+++ b/test/interface-tests/src/name-pubsub/cancel.js
@@ -1,6 +1,5 @@
 /* eslint-env mocha */
-
-import PeerId from 'peer-id'
+import { createPeerId } from '@libp2p/peer-id'
 import all from 'it-all'
 import { expect } from 'aegir/chai'
 import { getDescribe, getIt } from '../utils/mocha.js'
@@ -45,8 +44,8 @@ export function testCancel (factory, options) {
       // @ts-ignore this is mocha
       this.timeout(300 * 1000)
 
-      const peerId = await PeerId.create({ bits: 512 })
-      const id = peerId.toB58String()
+      const peerId = createPeerId()
+      const id = peerId.toString()
       const ipnsPath = `/ipns/${id}`
 
       const subs = await ipfs.name.pubsub.subs()

--- a/test/interface-tests/src/name-pubsub/pubsub.js
+++ b/test/interface-tests/src/name-pubsub/pubsub.js
@@ -2,7 +2,7 @@
 
 import { expect } from 'aegir/chai'
 import { getDescribe, getIt } from '../utils/mocha.js'
-import PeerId from 'peer-id'
+import { peerIdFromString } from '@libp2p/peer-id'
 import { isNode } from 'ipfs-utils/src/env.js'
 import * as ipns from 'ipns'
 import delay from 'delay'
@@ -183,8 +183,8 @@ export function testPubsub (factory, options) {
         throw new Error('No public key found in message data')
       }
 
-      const messageKey = await PeerId.createFromB58String(publishedMessage.from)
-      const pubKeyPeerId = await PeerId.createFromPubKey(publishedMessageData.pubKey)
+      const messageKey = peerIdFromString(publishedMessage.from)
+      const pubKeyPeerId = peerIdFromString(publishedMessageData.pubKey)
 
       expect(pubKeyPeerId.toB58String()).not.to.equal(messageKey.toB58String())
       expect(pubKeyPeerId.toB58String()).to.equal(testAccount.id)

--- a/test/interface-tests/src/name/publish.js
+++ b/test/interface-tests/src/name/publish.js
@@ -6,7 +6,7 @@ import { fixture } from './utils.js'
 import { expect } from 'aegir/chai'
 import { getDescribe, getIt } from '../utils/mocha.js'
 import last from 'it-last'
-import PeerId from 'peer-id'
+import { peerIdFromString } from '@libp2p/peer-id'
 
 /**
  * @typedef {import('ipfsd-ctl').Factory} Factory
@@ -59,7 +59,7 @@ export function testPublish (factory, options) {
       const res = await ipfs.name.publish(value, { allowOffline: true })
       expect(res).to.exist()
 
-      expect(PeerId.parse(res.name).toString()).to.equal(PeerId.parse(self.id).toString())
+      expect(peerIdFromString(res.name).toString()).to.equal(peerIdFromString(self.id).toString())
       expect(res.value).to.equal(`/ipfs/${value}`)
     })
 
@@ -91,7 +91,7 @@ export function testPublish (factory, options) {
 
       const res = await ipfs.name.publish(value, options)
       expect(res).to.exist()
-      expect(PeerId.parse(res.name).toString()).to.equal(PeerId.parse(self.id).toString())
+      expect(peerIdFromString(res.name).toString()).to.equal(peerIdFromString(self.id).toString())
       expect(res.value).to.equal(`/ipfs/${value}`)
     })
 
@@ -112,7 +112,7 @@ export function testPublish (factory, options) {
       const res = await ipfs.name.publish(value, options)
 
       expect(res).to.exist()
-      expect(PeerId.parse(res.name).toString()).to.equal(PeerId.parse(key.id).toString())
+      expect(peerIdFromString(res.name).toString()).to.equal(peerIdFromString(key.id).toString())
       expect(res.value).to.equal(`/ipfs/${value}`)
     })
   })

--- a/test/interface-tests/src/name/resolve.js
+++ b/test/interface-tests/src/name/resolve.js
@@ -4,7 +4,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { expect } from 'aegir/chai'
 import { getDescribe, getIt } from '../utils/mocha.js'
 import delay from 'delay'
-import PeerId from 'peer-id'
+import { peerIdFromString } from '@libp2p/peer-id'
 import last from 'it-last'
 import { CID } from 'multiformats/cid'
 import * as Digest from 'multiformats/hashes/digest'
@@ -66,7 +66,7 @@ export function testResolve (factory, options) {
 
       // Represent Peer ID as CIDv1 Base32
       // https://github.com/libp2p/specs/blob/master/RFC/0001-text-peerid-cid.md
-      const keyCid = CID.createV1(0x72, Digest.decode(PeerId.parse(peerId.toString()).toBytes()))
+      const keyCid = CID.createV1(0x72, Digest.decode(peerIdFromString(peerId.toString()).toBytes()))
       const resolvedPath = await last(ipfs.name.resolve(`/ipns/${keyCid}`))
 
       expect(resolvedPath).to.equal(`/ipfs/${cid}`)

--- a/test/interface-tests/src/swarm/addrs.js
+++ b/test/interface-tests/src/swarm/addrs.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import PeerId from 'peer-id'
+import { peerIdFromString } from '@libp2p/peer-id'
 import { isMultiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { getDescribe, getIt } from '../utils/mocha.js'
@@ -46,7 +46,7 @@ export function testAddrs (factory, options) {
       expect(peers).to.be.an('array')
 
       for (const peer of peers) {
-        expect(PeerId.parse(peer.id.toString())).to.be.ok()
+        expect(peerIdFromString(peer.id.toString())).to.be.ok()
         expect(peer).to.have.a.property('addrs').that.is.an('array')
 
         for (const ma of peer.addrs) {

--- a/test/interface-tests/src/swarm/peers.js
+++ b/test/interface-tests/src/swarm/peers.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 import { isMultiaddr } from '@multiformats/multiaddr'
-import PeerId from 'peer-id'
+import { peerIdFromString } from '@libp2p/peer-id'
 import delay from 'delay'
 import { isBrowser, isWebWorker } from 'ipfs-utils/src/env.js'
 import { expect } from 'aegir/chai'
@@ -52,7 +52,7 @@ export function testPeers (factory, options) {
       expect(peer).to.have.a.property('addr')
       expect(isMultiaddr(peer.addr)).to.equal(true)
       expect(peer.peer.toString()).not.to.be.undefined()
-      expect(PeerId.parse(peer.peer.toString())).to.be.ok()
+      expect(peerIdFromString(peer.peer.toString())).to.be.ok()
       expect(isMultiaddr(peer.addr)).to.equal(true)
       expect(peer).to.have.a.property('direction')
       expect(peer.direction).to.be.oneOf(['inbound', 'outbound'])


### PR DESCRIPTION
In this PR:

- removing deprecated `peer-id` https://github.com/libp2p/js-peer-id/tree/master
- move to `@libp2p/peer-id` to support multiformats update