### PR TITLE
deps: update @multiformats/multiaddr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out
 .docs
 docs
 .coverage
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@libp2p/crypto": "^1.0.11",
         "@libp2p/logger": "^2.0.5",
         "@libp2p/peer-id": "^2.0.0",
-        "@multiformats/multiaddr": "^11.1.5",
+        "@multiformats/multiaddr": "^12.1.10",
         "any-signal": "^3.0.1",
         "dag-jose": "^4.0.0",
         "err-code": "^3.0.1",
@@ -66,7 +66,8 @@
         "p-timeout": "^6.0.0",
         "pako": "^2.0.4",
         "readable-stream": "^4.2.0",
-        "sinon": "^15.0.1"
+        "sinon": "^15.0.1",
+        "typedoc": "^0.23.24"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1454,6 +1455,14 @@
       "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
       "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
     },
+    "node_modules/@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -2773,6 +2782,21 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@libp2p/interface": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.6.tgz",
+      "integrity": "sha512-Lzc5cS/hXuoXhuAbVIxJIHLCYmfPcbU0vVgrpMoiP1Qb2Q3ETU4A46GB8s8mWXgSU6tr9RcqerUqzFYD6+OAag==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.1.5",
+        "abortable-iterator": "^5.0.1",
+        "it-pushable": "^3.2.0",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "race-signal": "^1.0.0",
+        "uint8arraylist": "^2.4.3"
+      }
+    },
     "node_modules/@libp2p/interface-connection": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.7.tgz",
@@ -2787,6 +2811,34 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
       }
     },
     "node_modules/@libp2p/interface-dht": {
@@ -2867,6 +2919,34 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@libp2p/interface-peer-info/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-info/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      }
+    },
     "node_modules/@libp2p/interface-peer-store": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.7.tgz",
@@ -2882,6 +2962,36 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-store/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-store/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
       }
     },
     "node_modules/@libp2p/interface-pubsub": {
@@ -2941,6 +3051,67 @@
         "@multiformats/multiaddr": "^11.0.0",
         "it-stream-types": "^1.0.4"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/abortable-iterator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+      "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+      "dependencies": {
+        "get-iterator": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -3008,6 +3179,36 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@libp2p/utils/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      }
+    },
     "node_modules/@libp2p/websockets": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.2.tgz",
@@ -3034,23 +3235,11 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@multiformats/mafmt": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.0.3.tgz",
-      "integrity": "sha512-DvCQeZJgaC4kE3BLqMuW3gQkNAW14Z7I+yMt30Ze+wkfHkWSp+bICcHGihhtgfzYCumHA/vHlJ9n54mrCcmnvQ==",
+    "node_modules/@libp2p/websockets/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
       "dev": true,
-      "dependencies": {
-        "@multiformats/multiaddr": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.1.5.tgz",
-      "integrity": "sha512-sFppiscvhExFbSUdYl/4wBBOb5IjhYVpuRMBb6RgVjq7qTVHQDQeX3CEjQGdyy7+8A/cixL+fQez4RI+hltkLQ==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "dns-over-http-resolver": "^2.1.0",
@@ -3064,6 +3253,75 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@libp2p/websockets/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      }
+    },
+    "node_modules/@multiformats/mafmt": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.0.3.tgz",
+      "integrity": "sha512-DvCQeZJgaC4kE3BLqMuW3gQkNAW14Z7I+yMt30Ze+wkfHkWSp+bICcHGihhtgfzYCumHA/vHlJ9n54mrCcmnvQ==",
+      "dev": true,
+      "dependencies": {
+        "@multiformats/multiaddr": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/mafmt/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/mafmt/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "12.1.10",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.10.tgz",
+      "integrity": "sha512-Bi3nJ/SE17+te40OLxFOpr9CvRodusZZLYZb3e5a0w9RzQcHzfKnnlfqdysLXZ2W5vXgxCUL/Uhndl51Ff2S+Q==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^0.1.1",
+        "dns-over-http-resolver": "3.0.0",
+        "multiformats": "^12.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
+      }
+    },
     "node_modules/@multiformats/multiaddr-to-uri": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.2.tgz",
@@ -3071,6 +3329,43 @@
       "dependencies": {
         "@multiformats/multiaddr": "^11.0.0"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -8078,18 +8373,12 @@
       }
     },
     "node_modules/dns-over-http-resolver": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz",
-      "integrity": "sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-3.0.0.tgz",
+      "integrity": "sha512-5+BI+B7n8LKhNaEZBYErr+CBd9t5nYtjunByLhrLGtZ+i3TRgiU8yE87pCjEBu2KOwNsD9ljpSXEbZ4S8xih5g==",
       "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2",
-        "undici": "^5.12.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "debug": "^4.3.4",
+        "receptacle": "^1.3.2"
       }
     },
     "node_modules/doctrine": {
@@ -10905,8 +11194,7 @@
     "node_modules/get-iterator": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-2.0.0.tgz",
-      "integrity": "sha512-BDJawD5PU2gZv6Vlp8O28H4GnZcsr3h9gZUvnAP5xXP3WOy/QAoOsyMepSkw21jur+4t5Vppde72ChjhTIzxzg==",
-      "dev": true
+      "integrity": "sha512-BDJawD5PU2gZv6Vlp8O28H4GnZcsr3h9gZUvnAP5xXP3WOy/QAoOsyMepSkw21jur+4t5Vppde72ChjhTIzxzg=="
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
@@ -11996,6 +12284,34 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/ipfs-core-types/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-types/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      }
+    },
     "node_modules/ipfs-core-utils": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.18.0.tgz",
@@ -12025,6 +12341,34 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
       }
     },
     "node_modules/ipfs-unixfs": {
@@ -12169,6 +12513,46 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfsd-ctl/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfsd-ctl/node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfsd-ctl/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
       }
     },
     "node_modules/ipfsd-ctl/node_modules/multiformats": {
@@ -12498,6 +12882,36 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/is-ipfs/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/is-ipfs/node_modules/dns-over-http-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
       }
     },
     "node_modules/is-loopback-addr": {
@@ -13212,12 +13626,11 @@
       }
     },
     "node_modules/it-pushable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
-      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.3.tgz",
+      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
+      "dependencies": {
+        "p-defer": "^4.0.0"
       }
     },
     "node_modules/it-reader": {
@@ -19730,7 +20143,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
       "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -21540,6 +21952,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/race-signal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.0.2.tgz",
+      "integrity": "sha512-o3xNv0iTcIDQCXFlF6fPAMEBRjFxssgGoRqLbg06m+AdzEXXLUmoNOoUHTVz2NoBI8hHwKFKoC6IqyNtWr2bww=="
     },
     "node_modules/ramda": {
       "version": "0.25.0",
@@ -25380,6 +25797,15 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uint8-varint": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.2.tgz",
+      "integrity": "sha512-LZXmBT0jiHR7J4oKM1GUhtdLFW1yPauzI8NjJlotXn92TprO9u8VMvEVR4QMk8xhUVUd+2fqfU2/kGbVHYSSWw==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
     "node_modules/uint8arraylist": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
@@ -27428,6 +27854,14 @@
       "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
       "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
     },
+    "@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "requires": {
+        "@chainsafe/is-ip": "^2.0.1"
+      }
+    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -28499,6 +28933,42 @@
         "uint8arrays": "^4.0.2"
       }
     },
+    "@libp2p/interface": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.6.tgz",
+      "integrity": "sha512-Lzc5cS/hXuoXhuAbVIxJIHLCYmfPcbU0vVgrpMoiP1Qb2Q3ETU4A46GB8s8mWXgSU6tr9RcqerUqzFYD6+OAag==",
+      "requires": {
+        "@multiformats/multiaddr": "^12.1.5",
+        "abortable-iterator": "^5.0.1",
+        "it-pushable": "^3.2.0",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "race-signal": "^1.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "dependencies": {
+        "abortable-iterator": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+          "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+          "requires": {
+            "get-iterator": "^2.0.0",
+            "it-stream-types": "^2.0.1"
+          }
+        },
+        "it-stream-types": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+          "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg=="
+        },
+        "multiformats": {
+          "version": "12.1.3",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+          "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw=="
+        }
+      }
+    },
     "@libp2p/interface-connection": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.7.tgz",
@@ -28509,6 +28979,32 @@
         "@multiformats/multiaddr": "^11.0.0",
         "it-stream-types": "^1.0.4",
         "uint8arraylist": "^2.1.2"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        }
       }
     },
     "@libp2p/interface-dht": {
@@ -28563,6 +29059,32 @@
       "requires": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@multiformats/multiaddr": "^11.0.0"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        }
       }
     },
     "@libp2p/interface-peer-store": {
@@ -28576,6 +29098,34 @@
         "@libp2p/interface-record": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
         "@multiformats/multiaddr": "^11.0.0"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "dev": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        }
       }
     },
     "@libp2p/interface-pubsub": {
@@ -28622,6 +29172,34 @@
         "@libp2p/interfaces": "^3.0.0",
         "@multiformats/multiaddr": "^11.0.0",
         "it-stream-types": "^1.0.4"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "dev": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        }
       }
     },
     "@libp2p/interfaces": {
@@ -28668,6 +29246,34 @@
         "it-stream-types": "^1.0.4",
         "private-ip": "^3.0.0",
         "uint8arraylist": "^2.3.2"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "dev": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        }
       }
     },
     "@libp2p/websockets": {
@@ -28690,6 +29296,34 @@
         "p-defer": "^4.0.0",
         "p-timeout": "^6.0.0",
         "wherearewe": "^2.0.1"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "dev": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        }
       }
     },
     "@multiformats/mafmt": {
@@ -28699,19 +29333,55 @@
       "dev": true,
       "requires": {
         "@multiformats/multiaddr": "^11.0.0"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "dev": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        }
       }
     },
     "@multiformats/multiaddr": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.1.5.tgz",
-      "integrity": "sha512-sFppiscvhExFbSUdYl/4wBBOb5IjhYVpuRMBb6RgVjq7qTVHQDQeX3CEjQGdyy7+8A/cixL+fQez4RI+hltkLQ==",
+      "version": "12.1.10",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.10.tgz",
+      "integrity": "sha512-Bi3nJ/SE17+te40OLxFOpr9CvRodusZZLYZb3e5a0w9RzQcHzfKnnlfqdysLXZ2W5vXgxCUL/Uhndl51Ff2S+Q==",
       "requires": {
         "@chainsafe/is-ip": "^2.0.1",
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "multiformats": "^11.0.0",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^0.1.1",
+        "dns-over-http-resolver": "3.0.0",
+        "multiformats": "^12.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.1.3",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+          "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw=="
+        }
       }
     },
     "@multiformats/multiaddr-to-uri": {
@@ -28720,6 +29390,32 @@
       "integrity": "sha512-vrWmfFadmix5Ab9l//oRQdQ7O3J5bGJpJRMSm21bHlQB0XV4xtNU6vMZBVXeu3Su79LgflEp37cjTFE3yKf3Hw==",
       "requires": {
         "@multiformats/multiaddr": "^11.0.0"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        }
       }
     },
     "@multiformats/murmur3": {
@@ -32541,14 +33237,12 @@
       }
     },
     "dns-over-http-resolver": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz",
-      "integrity": "sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-3.0.0.tgz",
+      "integrity": "sha512-5+BI+B7n8LKhNaEZBYErr+CBd9t5nYtjunByLhrLGtZ+i3TRgiU8yE87pCjEBu2KOwNsD9ljpSXEbZ4S8xih5g==",
       "requires": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2",
-        "undici": "^5.12.0"
+        "debug": "^4.3.4",
+        "receptacle": "^1.3.2"
       }
     },
     "doctrine": {
@@ -34591,8 +35285,7 @@
     "get-iterator": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-2.0.0.tgz",
-      "integrity": "sha512-BDJawD5PU2gZv6Vlp8O28H4GnZcsr3h9gZUvnAP5xXP3WOy/QAoOsyMepSkw21jur+4t5Vppde72ChjhTIzxzg==",
-      "dev": true
+      "integrity": "sha512-BDJawD5PU2gZv6Vlp8O28H4GnZcsr3h9gZUvnAP5xXP3WOy/QAoOsyMepSkw21jur+4t5Vppde72ChjhTIzxzg=="
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -35406,6 +36099,32 @@
         "interface-datastore": "^7.0.0",
         "ipfs-unixfs": "^9.0.0",
         "multiformats": "^11.0.0"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        }
       }
     },
     "ipfs-core-utils": {
@@ -35433,6 +36152,32 @@
         "parse-duration": "^1.0.0",
         "timeout-abort-controller": "^3.0.0",
         "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        }
       }
     },
     "ipfs-unixfs": {
@@ -35545,6 +36290,40 @@
           "dev": true,
           "requires": {
             "multiformats": "^10.0.0"
+          }
+        },
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "dev": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "11.0.2",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+              "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+              "dev": true
+            }
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
           }
         },
         "multiformats": {
@@ -35782,6 +36561,34 @@
         "iso-url": "^1.1.3",
         "multiformats": "^11.0.0",
         "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "dev": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "dns-over-http-resolver": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+          "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.1",
+            "native-fetch": "^4.0.2",
+            "receptacle": "^1.3.2",
+            "undici": "^5.12.0"
+          }
+        }
       }
     },
     "is-loopback-addr": {
@@ -36293,9 +37100,12 @@
       }
     },
     "it-pushable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
-      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.3.tgz",
+      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
+      "requires": {
+        "p-defer": "^4.0.0"
+      }
     },
     "it-reader": {
       "version": "6.0.2",
@@ -40990,8 +41800,7 @@
     "p-defer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
-      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
-      "dev": true
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
     },
     "p-each-series": {
       "version": "2.2.0",
@@ -42299,6 +43108,11 @@
           }
         }
       }
+    },
+    "race-signal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.0.2.tgz",
+      "integrity": "sha512-o3xNv0iTcIDQCXFlF6fPAMEBRjFxssgGoRqLbg06m+AdzEXXLUmoNOoUHTVz2NoBI8hHwKFKoC6IqyNtWr2bww=="
     },
     "ramda": {
       "version": "0.25.0",
@@ -45240,6 +46054,15 @@
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true,
       "optional": true
+    },
+    "uint8-varint": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.2.tgz",
+      "integrity": "sha512-LZXmBT0jiHR7J4oKM1GUhtdLFW1yPauzI8NjJlotXn92TprO9u8VMvEVR4QMk8xhUVUd+2fqfU2/kGbVHYSSWw==",
+      "requires": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      }
     },
     "uint8arraylist": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "@libp2p/crypto": "^1.0.11",
     "@libp2p/logger": "^2.0.5",
     "@libp2p/peer-id": "^2.0.0",
-    "@multiformats/multiaddr": "^11.1.5",
+    "@multiformats/multiaddr": "^12.1.10",
     "any-signal": "^3.0.1",
     "dag-jose": "^4.0.0",
     "err-code": "^3.0.1",

--- a/test/interface-tests/src/pin/remote/add.js
+++ b/test/interface-tests/src/pin/remote/add.js
@@ -93,12 +93,12 @@ export function testAdd (factory, options) {
       expect(winner).to.equal(timeout)
 
       // trigger status change on the mock service
-      ipfs.pin.remote.add(cid, {
+      await ipfs.pin.remote.add(cid, {
         service: SERVICE,
         name: 'pinned-block'
       })
 
-      expect(await result).to.deep.equal({
+      await expect(result).to.eventually.deep.equal({
         cid,
         status: 'pinned',
         name: ''

--- a/test/node/request-api.js
+++ b/test/node/request-api.js
@@ -117,7 +117,7 @@ describe('error handling', function () {
 
     await expect(httpClient('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json'))
       .to.eventually.be.rejected()
-      .and.to.have.property('message').that.includes('Unexpected token M in JSON at position 2')
+      .and.to.have.property('message').that.includes('invalid json response body')
 
     server.close()
   })

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -25,7 +25,9 @@ describe('.pubsub', function () {
       ipfs = ctl.api
     })
 
-    afterEach(function () { return f.clean() })
+    afterEach(async function () {
+      await f.clean()
+    })
 
     it('.onError when connection is closed', async function () {
       const topic = 'gossipboom'


### PR DESCRIPTION
- chore: ignore .DS_Store files
- fix: tests and update multiformats/multiaddr

This work is part of https://github.com/ipfs/ipfs-webui/issues/2176

---

Also, if you look at the Actions of this repo, many tests have been failing in the CI for a while. This PR addresses that, as well as updates `@multiformats/multiaddr`

![image](https://github.com/ipfs/js-kubo-rpc-client/assets/1173416/76c15903-3ab5-4e53-b27d-eb8ed23c05bf)