### PR TITLE
fix: isOnline should return false when node is offline

### DIFF
--- a/src/is-online.ts
+++ b/src/is-online.ts
@@ -6,8 +6,12 @@ export function createIsOnline (client: HTTPRPCClient): KuboRPCClient['isOnline'
   const id = createId(client)
 
   return async function isOnline (options = {}) {
-    const res = await id(options)
+    try {
+      const res = await id(options)
 
-    return Boolean(res?.addresses?.length)
+      return Boolean(res?.addresses?.length)
+    } catch {
+      return false
+    }
   }
 }

--- a/test/is-online.spec.ts
+++ b/test/is-online.spec.ts
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import { factory } from './utils/factory.js'
+import type { KuboRPCClient } from '../src/index.js'
+
+const f = factory()
+
+describe('.isOnline', function () {
+  this.timeout(20 * 1000)
+
+  let ipfs: KuboRPCClient
+
+  before(async function () {
+    ipfs = (await f.spawn()).api
+  })
+
+  after(async function () { return f.clean() })
+
+  it('should return true when the node is online', async function () {
+    await expect(ipfs.isOnline()).to.eventually.be.true()
+  })
+
+  it('should return false when the node is offline', async function () {
+    await f.controllers[0].stop()
+    await expect(ipfs.isOnline()).to.eventually.be.false()
+  })
+})


### PR DESCRIPTION
If the node is offline, trying to invoke the api client results in an error being thrown.

If this happens the node is not online so return false instead.