### PR TITLE
fix: export createKuboRPCClient function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -494,6 +494,7 @@ export function create (options: string | Multiaddr | URL | Options = {}): KuboR
   return createKuboRPCClient(options)
 }
 
+export { create as createKuboRPCClient }
 export { CID } from 'multiformats/cid'
 export { multiaddr } from '@multiformats/multiaddr'
 export * from './lib/glob-source.js'


### PR DESCRIPTION
The `create` function is too generic, it often clashes with other functions so export a copy with a more obvious name.