### PR TITLE
feat: expose allowBigBlock option

### DIFF
--- a/src/block/index.ts
+++ b/src/block/index.ts
@@ -26,6 +26,13 @@ export interface BlockPutOptions extends HTTPRPCOptions {
    * Pin this block when adding. (Defaults to `false`)
    */
   pin?: boolean
+
+  /**
+   * Allow creating blocks larger than 1MB
+   *
+   * @default false
+   */
+  allowBigBlock?: boolean
 }
 
 export interface BlockRmOptions extends HTTPRPCOptions {


### PR DESCRIPTION
To allow adding large blocks to the blockstore, expose the `--allow-big-block` flag from `ipfs block put`.