### PR TITLE
Fix: Ensure File Argument 'key' is Provided in kubo-rpc-client

### DIFF
--- a/src/key/import.ts
+++ b/src/key/import.ts
@@ -4,16 +4,23 @@ import type { KeyAPI } from './index.js'
 import type { HTTPRPCClient } from '../lib/core.js'
 
 export function createImport (client: HTTPRPCClient): KeyAPI['import'] {
-  return async function importKey (name, pem, password, options = {}) {
+  return async function importKey (name, file, ipnsBase, format, options = {}) {
+    const body = new FormData()
+    body.append('key', file)
+
     const res = await client.post('key/import', {
       signal: options.signal,
       searchParams: toUrlSearchParams({
         arg: name,
-        pem,
-        password,
+        format,
+        'ipns-base': ipnsBase,
         ...options
       }),
-      headers: options.headers
+      body,
+      headers: {
+        ...options.headers,
+        'Content-Type': 'multipart/form-data'
+      }
     })
     const data = await res.json()
 

--- a/src/key/index.ts
+++ b/src/key/index.ts
@@ -93,18 +93,23 @@ export interface KeyAPI {
   rename(oldName: string, newName: string, options?: HTTPRPCOptions): Promise<KeyRenameResult>
 
   /**
-   * Remove a key
+   * import a key
+   *
+   * @param name - The name of the key
+   * @param file - The file to import
+   * @param ipnsBase - The base of the IPNS name default is base36, Takes {b58mh|base36|k|base32|b...}
+   * @param format - The format of the key, either  libp2p-protobuf-cleartext or pem-pkcs8-cleartext
    *
    * @example
    * ```js
-   * const key = await ipfs.key.import('clone', pem, 'password')
+   * const key = await ipfs.key.import('clone', new File(['keycontent'], 'test.key', { type: 'text/plain' }))
    *
    * console.log(key)
    * // { id: 'QmQRiays958UM7norGRQUG3tmrLq8pJdmJarwYSk2eLthQ',
    * //   name: 'clone' }
    * ```
    */
-  import(name: string, pem: string, password: string, options?: HTTPRPCOptions): Promise<Key>
+  import(name: string, file: File, ipnsBase?: string, format?: string, options?: HTTPRPCOptions): Promise<Key>
 }
 
 export function createKey (client: HTTPRPCClient): KeyAPI {


### PR DESCRIPTION
**Description**

This PR addresses the issue where the key argument for files is incorrectly required, resolving [#144](https://github.com/ipfs/js-kubo-rpc-client/issues/144). The implementation follows the IPFS documentation to ensure correct handling.

**Changes**

Fixed the bug that caused the "file argument 'key' is required" error.
Adjusted the implementation to align with IPFS API expectations.
Successfully tested the fix via RPC calls.

**Blockers**

Encountered a conflict between the current type changes in the KuboRPCClient interface on the repo and the version published on npm, preventing unit test execution.
Despite this, manual testing through RPC confirmed the fix works as expected.
