### PR TITLE
deps: parse-duration from 2.1.2 to 2.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "it-to-stream": "^1.0.0",
         "merge-options": "^3.0.4",
         "multiformats": "^13.1.0",
-        "nanoid": "^5.0.7",
+        "nanoid": "^5.1.5",
         "native-fetch": "^4.0.2",
         "parse-duration": "^2.1.4",
         "react-native-fetch-api": "^3.0.0",
@@ -15692,9 +15692,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.0.tgz",
-      "integrity": "sha512-zDAl/llz8Ue/EblwSYwdxGBYfj46IM1dhjVi8dyp9LQffoIGxJEAHj2oeZ4uNcgycSRcQ83CnfcZqEJzVDLcDw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "it-to-stream": "^1.0.0",
     "merge-options": "^3.0.4",
     "multiformats": "^13.1.0",
-    "nanoid": "^5.0.7",
+    "nanoid": "^5.1.5",
     "native-fetch": "^4.0.2",
     "parse-duration": "^2.1.4",
     "react-native-fetch-api": "^3.0.0",


### PR DESCRIPTION
parse-duration has a Regex Denial of Service that results in event loop delay and out of memory < 2.1.3