### PR TITLE
feat: add pin name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,20 @@ const ipfs = create({ timeout: '2m' })
 
 We run tests by executing `npm test` in a terminal window. This will run both Node.js and Browser tests, both in Chrome and PhantomJS. To ensure that the module conforms with the [`interface-ipfs-core`](https://github.com/ipfs/js-ipfs/tree/master/packages/interface-ipfs-core) spec, we run the batch of tests provided by the interface module, which can be found [here](https://github.com/ipfs/js-ipfs/tree/master/packages/interface-ipfs-core/src).
 
+#### Testing with Custom Kubo Binary
+
+By default, tests use the kubo binary from `node_modules`. To test with a custom kubo binary (e.g., a development version), use the `IPFS_GO_EXEC` environment variable:
+
+```bash
+# Test with a custom kubo binary
+IPFS_GO_EXEC=/path/to/custom/kubo npm test
+
+# Example: testing with locally built kubo
+IPFS_GO_EXEC=/home/user/kubo/cmd/ipfs/ipfs npm test
+```
+
+This is particularly useful when developing features that require changes to both kubo and this client.
+
 ## Historical context
 
 This module started as a direct mapping from the go-ipfs cli to a JavaScript implementation, although this was useful and familiar to a lot of developers that were coming to IPFS for the first time, it also created some confusion on how to operate the core of IPFS and have access to the full capacity of the protocol. After much consideration, we decided to create `interface-ipfs-core` with the goal of standardizing the interface of a core implementation of IPFS, and keep the utility functions the IPFS community learned to use and love, such as reading files from disk and storing them directly to IPFS.

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "it-pipe": "^3.0.1",
         "it-tar": "^6.0.0",
         "it-to-buffer": "^4.0.5",
-        "kubo": "^0.29.0",
+        "kubo": "^0.37.0",
         "mock-ipfs-pinning-service": "^0.4.2",
         "nock": "^14.0.1",
         "p-defer": "^4.0.0",
@@ -13175,9 +13175,9 @@
       }
     },
     "node_modules/kubo": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.29.0.tgz",
-      "integrity": "sha512-y1g+971iy72r0LECZuvvFsmGjWsCAZhT0/U3kBw/71Bm9kRQk+UcpHaSWv2HyXggFP2EDHRufQJeouwu22sliw==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.37.0.tgz",
+      "integrity": "sha512-TjU04/gbJd+pFvc2s2r0mKF2LhgSCWNko0TYpaWDiWI9HPX6k6PvNQinMfwnP8EvyQgfhH50MNrVXNvJQ5dfoQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "it-pipe": "^3.0.1",
         "it-tar": "^6.0.0",
         "it-to-buffer": "^4.0.5",
-        "kubo": "^0.37.0",
+        "kubo": "^0.38.0-rc1",
         "mock-ipfs-pinning-service": "^0.4.2",
         "nock": "^14.0.1",
         "p-defer": "^4.0.0",
@@ -13175,9 +13175,9 @@
       }
     },
     "node_modules/kubo": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.37.0.tgz",
-      "integrity": "sha512-TjU04/gbJd+pFvc2s2r0mKF2LhgSCWNko0TYpaWDiWI9HPX6k6PvNQinMfwnP8EvyQgfhH50MNrVXNvJQ5dfoQ==",
+      "version": "0.38.0-rc1",
+      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.38.0-rc1.tgz",
+      "integrity": "sha512-xgMCG6TDj51E5iVXHnor1sn97UbM8yBUnHVUBXYkyb6aqa7ZKt65LYUSxL8dkwAhoNsZNJSqaVZOCVoLsIzgkw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "it-pipe": "^3.0.1",
         "it-tar": "^6.0.0",
         "it-to-buffer": "^4.0.5",
-        "kubo": "^0.38.0-rc1",
+        "kubo": "^0.38.0",
         "mock-ipfs-pinning-service": "^0.4.2",
         "nock": "^14.0.1",
         "p-defer": "^4.0.0",
@@ -108,15 +108,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -447,9 +447,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -457,9 +457,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -492,27 +492,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1231,28 +1231,25 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1278,14 +1275,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1324,6 +1321,594 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cspell/cspell-bundled-dicts": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.19.4.tgz",
+      "integrity": "sha512-2ZRcZP/ncJ5q953o8i+R0fb8+14PDt5UefUNMrFZZHvfTI0jukAASOQeLY+WT6ASZv6CgbPrApAdbppy9FaXYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-ada": "^4.1.0",
+        "@cspell/dict-al": "^1.1.0",
+        "@cspell/dict-aws": "^4.0.10",
+        "@cspell/dict-bash": "^4.2.0",
+        "@cspell/dict-companies": "^3.1.15",
+        "@cspell/dict-cpp": "^6.0.8",
+        "@cspell/dict-cryptocurrencies": "^5.0.4",
+        "@cspell/dict-csharp": "^4.0.6",
+        "@cspell/dict-css": "^4.0.17",
+        "@cspell/dict-dart": "^2.3.0",
+        "@cspell/dict-data-science": "^2.0.8",
+        "@cspell/dict-django": "^4.1.4",
+        "@cspell/dict-docker": "^1.1.13",
+        "@cspell/dict-dotnet": "^5.0.9",
+        "@cspell/dict-elixir": "^4.0.7",
+        "@cspell/dict-en_us": "^4.4.3",
+        "@cspell/dict-en-common-misspellings": "^2.0.10",
+        "@cspell/dict-en-gb": "1.1.33",
+        "@cspell/dict-filetypes": "^3.0.11",
+        "@cspell/dict-flutter": "^1.1.0",
+        "@cspell/dict-fonts": "^4.0.4",
+        "@cspell/dict-fsharp": "^1.1.0",
+        "@cspell/dict-fullstack": "^3.2.6",
+        "@cspell/dict-gaming-terms": "^1.1.1",
+        "@cspell/dict-git": "^3.0.4",
+        "@cspell/dict-golang": "^6.0.20",
+        "@cspell/dict-google": "^1.0.8",
+        "@cspell/dict-haskell": "^4.0.5",
+        "@cspell/dict-html": "^4.0.11",
+        "@cspell/dict-html-symbol-entities": "^4.0.3",
+        "@cspell/dict-java": "^5.0.11",
+        "@cspell/dict-julia": "^1.1.0",
+        "@cspell/dict-k8s": "^1.0.10",
+        "@cspell/dict-kotlin": "^1.1.0",
+        "@cspell/dict-latex": "^4.0.3",
+        "@cspell/dict-lorem-ipsum": "^4.0.4",
+        "@cspell/dict-lua": "^4.0.7",
+        "@cspell/dict-makefile": "^1.0.4",
+        "@cspell/dict-markdown": "^2.0.10",
+        "@cspell/dict-monkeyc": "^1.0.10",
+        "@cspell/dict-node": "^5.0.7",
+        "@cspell/dict-npm": "^5.2.1",
+        "@cspell/dict-php": "^4.0.14",
+        "@cspell/dict-powershell": "^5.0.14",
+        "@cspell/dict-public-licenses": "^2.0.13",
+        "@cspell/dict-python": "^4.2.17",
+        "@cspell/dict-r": "^2.1.0",
+        "@cspell/dict-ruby": "^5.0.8",
+        "@cspell/dict-rust": "^4.0.11",
+        "@cspell/dict-scala": "^5.0.7",
+        "@cspell/dict-shell": "^1.1.0",
+        "@cspell/dict-software-terms": "^5.0.5",
+        "@cspell/dict-sql": "^2.2.0",
+        "@cspell/dict-svelte": "^1.0.6",
+        "@cspell/dict-swift": "^2.0.5",
+        "@cspell/dict-terraform": "^1.1.1",
+        "@cspell/dict-typescript": "^3.2.1",
+        "@cspell/dict-vue": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/cspell-json-reporter": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.19.4.tgz",
+      "integrity": "sha512-pOlUtLUmuDdTIOhDTvWxxta0Wm8RCD/p1V0qUqeP6/Ups1ajBI4FWEpRFd7yMBTUHeGeSNicJX5XeX7wNbAbLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-types": "8.19.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/cspell-pipe": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.19.4.tgz",
+      "integrity": "sha512-GNAyk+7ZLEcL2fCMT5KKZprcdsq3L1eYy3e38/tIeXfbZS7Sd1R5FXUe6CHXphVWTItV39TvtLiDwN/2jBts9A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/cspell-resolver": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.19.4.tgz",
+      "integrity": "sha512-S8vJMYlsx0S1D60glX8H2Jbj4mD8519VjyY8lu3fnhjxfsl2bDFZvF3ZHKsLEhBE+Wh87uLqJDUJQiYmevHjDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/cspell-service-bus": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.19.4.tgz",
+      "integrity": "sha512-uhY+v8z5JiUogizXW2Ft/gQf3eWrh5P9036jN2Dm0UiwEopG/PLshHcDjRDUiPdlihvA0RovrF0wDh4ptcrjuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/cspell-types": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.19.4.tgz",
+      "integrity": "sha512-ekMWuNlFiVGfsKhfj4nmc8JCA+1ZltwJgxiKgDuwYtR09ie340RfXFF6YRd2VTW5zN7l4F1PfaAaPklVz6utSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/dict-ada": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.1.1.tgz",
+      "integrity": "sha512-E+0YW9RhZod/9Qy2gxfNZiHJjCYFlCdI69br1eviQQWB8yOTJX0JHXLs79kOYhSW0kINPVUdvddEBe6Lu6CjGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-al": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-al/-/dict-al-1.1.1.tgz",
+      "integrity": "sha512-sD8GCaZetgQL4+MaJLXqbzWcRjfKVp8x+px3HuCaaiATAAtvjwUQ5/Iubiqwfd1boIh2Y1/3EgM3TLQ7Q8e0wQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-aws": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.15.tgz",
+      "integrity": "sha512-aPY7VVR5Os4rz36EaqXBAEy14wR4Rqv+leCJ2Ug/Gd0IglJpM30LalF3e2eJChnjje3vWoEC0Rz3+e5gpZG+Kg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-bash": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.2.1.tgz",
+      "integrity": "sha512-SBnzfAyEAZLI9KFS7DUG6Xc1vDFuLllY3jz0WHvmxe8/4xV3ufFE3fGxalTikc1VVeZgZmxYiABw4iGxVldYEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-shell": "1.1.1"
+      }
+    },
+    "node_modules/@cspell/dict-companies": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.5.tgz",
+      "integrity": "sha512-H51R0w7c6RwJJPqH7Gs65tzP6ouZsYDEHmmol6MIIk0kQaOIBuFP2B3vIxHLUr2EPRVFZsMW8Ni7NmVyaQlwsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-cpp": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.12.tgz",
+      "integrity": "sha512-N4NsCTttVpMqQEYbf0VQwCj6np+pJESov0WieCN7R/0aByz4+MXEiDieWWisaiVi8LbKzs1mEj4ZTw5K/6O2UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-cryptocurrencies": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.5.tgz",
+      "integrity": "sha512-R68hYYF/rtlE6T/dsObStzN5QZw+0aQBinAXuWCVqwdS7YZo0X33vGMfChkHaiCo3Z2+bkegqHlqxZF4TD3rUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-csharp": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.7.tgz",
+      "integrity": "sha512-H16Hpu8O/1/lgijFt2lOk4/nnldFtQ4t8QHbyqphqZZVE5aS4J/zD/WvduqnLY21aKhZS6jo/xF5PX9jyqPKUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-css": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.18.tgz",
+      "integrity": "sha512-EF77RqROHL+4LhMGW5NTeKqfUd/e4OOv6EDFQ/UQQiFyWuqkEKyEz0NDILxOFxWUEVdjT2GQ2cC7t12B6pESwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-dart": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.3.1.tgz",
+      "integrity": "sha512-xoiGnULEcWdodXI6EwVyqpZmpOoh8RA2Xk9BNdR7DLamV/QMvEYn8KJ7NlRiTSauJKPNkHHQ5EVHRM6sTS7jdg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-data-science": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.9.tgz",
+      "integrity": "sha512-wTOFMlxv06veIwKdXUwdGxrQcK44Zqs426m6JGgHIB/GqvieZQC5n0UI+tUm5OCxuNyo4OV6mylT4cRMjtKtWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-django": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.5.tgz",
+      "integrity": "sha512-AvTWu99doU3T8ifoMYOMLW2CXKvyKLukPh1auOPwFGHzueWYvBBN+OxF8wF7XwjTBMMeRleVdLh3aWCDEX/ZWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-docker": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.16.tgz",
+      "integrity": "sha512-UiVQ5RmCg6j0qGIxrBnai3pIB+aYKL3zaJGvXk1O/ertTKJif9RZikKXCEgqhaCYMweM4fuLqWSVmw3hU164Iw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-dotnet": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.10.tgz",
+      "integrity": "sha512-ooar8BP/RBNP1gzYfJPStKEmpWy4uv/7JCq6FOnJLeD1yyfG3d/LFMVMwiJo+XWz025cxtkM3wuaikBWzCqkmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-elixir": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.8.tgz",
+      "integrity": "sha512-CyfphrbMyl4Ms55Vzuj+mNmd693HjBFr9hvU+B2YbFEZprE5AG+EXLYTMRWrXbpds4AuZcvN3deM2XVB80BN/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-en_us": {
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.19.tgz",
+      "integrity": "sha512-JYYgzhGqSGuIMNY1cTlmq3zrNpehrExMHqLmLnSM2jEGFeHydlL+KLBwBYxMy4e73w+p1+o/rmAiGsMj9g3MCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-en-common-misspellings": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.6.tgz",
+      "integrity": "sha512-xV9yryOqZizbSqxRS7kSVRrxVEyWHUqwdY56IuT7eAWGyTCJNmitXzXa4p+AnEbhL+AB2WLynGVSbNoUC3ceFA==",
+      "dev": true,
+      "license": "CC BY-SA 4.0"
+    },
+    "node_modules/@cspell/dict-en-gb": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-1.1.33.tgz",
+      "integrity": "sha512-tKSSUf9BJEV+GJQAYGw5e+ouhEe2ZXE620S7BLKe3ZmpnjlNG9JqlnaBhkIMxKnNFkLY2BP/EARzw31AZnOv4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-filetypes": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.13.tgz",
+      "integrity": "sha512-g6rnytIpQlMNKGJT1JKzWkC+b3xCliDKpQ3ANFSq++MnR4GaLiifaC4JkVON11Oh/UTplYOR1nY3BR4X30bswA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-flutter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.1.1.tgz",
+      "integrity": "sha512-UlOzRcH2tNbFhZmHJN48Za/2/MEdRHl2BMkCWZBYs+30b91mWvBfzaN4IJQU7dUZtowKayVIF9FzvLZtZokc5A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fonts": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.5.tgz",
+      "integrity": "sha512-BbpkX10DUX/xzHs6lb7yzDf/LPjwYIBJHJlUXSBXDtK/1HaeS+Wqol4Mlm2+NAgZ7ikIE5DQMViTgBUY3ezNoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fsharp": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.1.1.tgz",
+      "integrity": "sha512-imhs0u87wEA4/cYjgzS0tAyaJpwG7vwtC8UyMFbwpmtw+/bgss+osNfyqhYRyS/ehVCWL17Ewx2UPkexjKyaBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fullstack": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.7.tgz",
+      "integrity": "sha512-IxEk2YAwAJKYCUEgEeOg3QvTL4XLlyArJElFuMQevU1dPgHgzWElFevN5lsTFnvMFA1riYsVinqJJX0BanCFEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-gaming-terms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.2.tgz",
+      "integrity": "sha512-9XnOvaoTBscq0xuD6KTEIkk9hhdfBkkvJAIsvw3JMcnp1214OCGW8+kako5RqQ2vTZR3Tnf3pc57o7VgkM0q1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-git": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.7.tgz",
+      "integrity": "sha512-odOwVKgfxCQfiSb+nblQZc4ErXmnWEnv8XwkaI4sNJ7cNmojnvogYVeMqkXPjvfrgEcizEEA4URRD2Ms5PDk1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-golang": {
+      "version": "6.0.23",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.23.tgz",
+      "integrity": "sha512-oXqUh/9dDwcmVlfUF5bn3fYFqbUzC46lXFQmi5emB0vYsyQXdNWsqi6/yH3uE7bdRE21nP7Yo0mR1jjFNyLamg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-google": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.9.tgz",
+      "integrity": "sha512-biL65POqialY0i4g6crj7pR6JnBkbsPovB2WDYkj3H4TuC/QXv7Pu5pdPxeUJA6TSCHI7T5twsO4VSVyRxD9CA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-haskell": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.6.tgz",
+      "integrity": "sha512-ib8SA5qgftExpYNjWhpYIgvDsZ/0wvKKxSP+kuSkkak520iPvTJumEpIE+qPcmJQo4NzdKMN8nEfaeci4OcFAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-html": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.12.tgz",
+      "integrity": "sha512-JFffQ1dDVEyJq6tCDWv0r/RqkdSnV43P2F/3jJ9rwLgdsOIXwQbXrz6QDlvQLVvNSnORH9KjDtenFTGDyzfCaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-html-symbol-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.4.tgz",
+      "integrity": "sha512-afea+0rGPDeOV9gdO06UW183Qg6wRhWVkgCFwiO3bDupAoyXRuvupbb5nUyqSTsLXIKL8u8uXQlJ9pkz07oVXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-java": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.12.tgz",
+      "integrity": "sha512-qPSNhTcl7LGJ5Qp6VN71H8zqvRQK04S08T67knMq9hTA8U7G1sTKzLmBaDOFhq17vNX/+rT+rbRYp+B5Nwza1A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-julia": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.1.1.tgz",
+      "integrity": "sha512-WylJR9TQ2cgwd5BWEOfdO3zvDB+L7kYFm0I9u0s9jKHWQ6yKmfKeMjU9oXxTBxIufhCXm92SKwwVNAC7gjv+yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-k8s": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.12.tgz",
+      "integrity": "sha512-2LcllTWgaTfYC7DmkMPOn9GsBWsA4DZdlun4po8s2ysTP7CPEnZc1ZfK6pZ2eI4TsZemlUQQ+NZxMe9/QutQxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-kotlin": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-kotlin/-/dict-kotlin-1.1.1.tgz",
+      "integrity": "sha512-J3NzzfgmxRvEeOe3qUXnSJQCd38i/dpF9/t3quuWh6gXM+krsAXP75dY1CzDmS8mrJAlBdVBeAW5eAZTD8g86Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-latex": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-4.0.4.tgz",
+      "integrity": "sha512-YdTQhnTINEEm/LZgTzr9Voz4mzdOXH7YX+bSFs3hnkUHCUUtX/mhKgf1CFvZ0YNM2afjhQcmLaR9bDQVyYBvpA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-lorem-ipsum": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.5.tgz",
+      "integrity": "sha512-9a4TJYRcPWPBKkQAJ/whCu4uCAEgv/O2xAaZEI0n4y1/l18Yyx8pBKoIX5QuVXjjmKEkK7hi5SxyIsH7pFEK9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-lua": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.8.tgz",
+      "integrity": "sha512-N4PkgNDMu9JVsRu7JBS/3E/dvfItRgk9w5ga2dKq+JupP2Y3lojNaAVFhXISh4Y0a6qXDn2clA6nvnavQ/jjLA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-makefile": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.5.tgz",
+      "integrity": "sha512-4vrVt7bGiK8Rx98tfRbYo42Xo2IstJkAF4tLLDMNQLkQ86msDlYSKG1ZCk8Abg+EdNcFAjNhXIiNO+w4KflGAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-markdown": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.12.tgz",
+      "integrity": "sha512-ufwoliPijAgWkD/ivAMC+A9QD895xKiJRF/fwwknQb7kt7NozTLKFAOBtXGPJAB4UjhGBpYEJVo2elQ0FCAH9A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@cspell/dict-css": "^4.0.18",
+        "@cspell/dict-html": "^4.0.12",
+        "@cspell/dict-html-symbol-entities": "^4.0.4",
+        "@cspell/dict-typescript": "^3.2.3"
+      }
+    },
+    "node_modules/@cspell/dict-monkeyc": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.11.tgz",
+      "integrity": "sha512-7Q1Ncu0urALI6dPTrEbSTd//UK0qjRBeaxhnm8uY5fgYNFYAG+u4gtnTIo59S6Bw5P++4H3DiIDYoQdY/lha8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-node": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.8.tgz",
+      "integrity": "sha512-AirZcN2i84ynev3p2/1NCPEhnNsHKMz9zciTngGoqpdItUb2bDt1nJBjwlsrFI78GZRph/VaqTVFwYikmncpXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-npm": {
+      "version": "5.2.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.17.tgz",
+      "integrity": "sha512-0yp7lBXtN3CtxBrpvTu/yAuPdOHR2ucKzPxdppc3VKO068waZNpKikn1NZCzBS3dIAFGVITzUPtuTXxt9cxnSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-php": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.15.tgz",
+      "integrity": "sha512-iepGB2gtToMWSTvybesn4/lUp4LwXcEm0s8vasJLP76WWVkq1zYjmeS+WAIzNgsuURyZ/9mGqhS0CWMuo74ODw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-powershell": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.15.tgz",
+      "integrity": "sha512-l4S5PAcvCFcVDMJShrYD0X6Huv9dcsQPlsVsBGbH38wvuN7gS7+GxZFAjTNxDmTY1wrNi1cCatSg6Pu2BW4rgg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-public-licenses": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.15.tgz",
+      "integrity": "sha512-cJEOs901H13Pfy0fl4dCD1U+xpWIMaEPq8MeYU83FfDZvellAuSo4GqWCripfIqlhns/L6+UZEIJSOZnjgy7Wg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-python": {
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.19.tgz",
+      "integrity": "sha512-9S2gTlgILp1eb6OJcVZeC8/Od83N8EqBSg5WHVpx97eMMJhifOzePkE0kDYjyHMtAFznCQTUu0iQEJohNQ5B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-data-science": "^2.0.9"
+      }
+    },
+    "node_modules/@cspell/dict-r": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.1.1.tgz",
+      "integrity": "sha512-71Ka+yKfG4ZHEMEmDxc6+blFkeTTvgKbKAbwiwQAuKl3zpqs1Y0vUtwW2N4b3LgmSPhV3ODVY0y4m5ofqDuKMw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-ruby": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.9.tgz",
+      "integrity": "sha512-H2vMcERMcANvQshAdrVx0XoWaNX8zmmiQN11dZZTQAZaNJ0xatdJoSqY8C8uhEMW89bfgpN+NQgGuDXW2vmXEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-rust": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.12.tgz",
+      "integrity": "sha512-z2QiH+q9UlNhobBJArvILRxV8Jz0pKIK7gqu4TgmEYyjiu1TvnGZ1tbYHeu9w3I/wOP6UMDoCBTty5AlYfW0mw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-scala": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.8.tgz",
+      "integrity": "sha512-YdftVmumv8IZq9zu1gn2U7A4bfM2yj9Vaupydotyjuc+EEZZSqAafTpvW/jKLWji2TgybM1L2IhmV0s/Iv9BTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-shell": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-shell/-/dict-shell-1.1.1.tgz",
+      "integrity": "sha512-T37oYxE7OV1x/1D4/13Y8JZGa1QgDCXV7AVt3HLXjn0Fe3TaNDvf5sU0fGnXKmBPqFFrHdpD3uutAQb1dlp15g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-software-terms": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.1.8.tgz",
+      "integrity": "sha512-iwCHLP11OmVHEX2MzE8EPxpPw7BelvldxWe5cJ3xXIDL8TjF2dBTs2noGcrqnZi15SLYIlO8897BIOa33WHHZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-sql": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.2.1.tgz",
+      "integrity": "sha512-qDHF8MpAYCf4pWU8NKbnVGzkoxMNrFqBHyG/dgrlic5EQiKANCLELYtGlX5auIMDLmTf1inA0eNtv74tyRJ/vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-svelte": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.7.tgz",
+      "integrity": "sha512-hGZsGqP0WdzKkdpeVLBivRuSNzOTvN036EBmpOwxH+FTY2DuUH7ecW+cSaMwOgmq5JFSdTcbTNFlNC8HN8lhaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-swift": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.6.tgz",
+      "integrity": "sha512-PnpNbrIbex2aqU1kMgwEKvCzgbkHtj3dlFLPMqW1vSniop7YxaDTtvTUO4zA++ugYAEL+UK8vYrBwDPTjjvSnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-terraform": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.1.3.tgz",
+      "integrity": "sha512-gr6wxCydwSFyyBKhBA2xkENXtVFToheqYYGFvlMZXWjviynXmh+NK/JTvTCk/VHk3+lzbO9EEQKee6VjrAUSbA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-typescript": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
+      "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-vue": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.5.tgz",
+      "integrity": "sha512-Mqutb8jbM+kIcywuPQCCaK5qQHTdaByoEO2J9LKFy3sqAdiBogNkrplqUK0HyyRFgCfbJUgjz3N85iCMcWH0JA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dynamic-import": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.19.4.tgz",
+      "integrity": "sha512-0LLghC64+SiwQS20Sa0VfFUBPVia1rNyo0bYeIDoB34AA3qwguDBVJJkthkpmaP1R2JeR/VmxmJowuARc4ZUxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "8.19.4",
+        "import-meta-resolve": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@cspell/filetypes": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.19.4.tgz",
+      "integrity": "sha512-D9hOCMyfKtKjjqQJB8F80PWsjCZhVGCGUMiDoQpcta0e+Zl8vHgzwaC0Ai4QUGBhwYEawHGiWUd7Y05u/WXiNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/strong-weak-map": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.19.4.tgz",
+      "integrity": "sha512-MUfFaYD8YqVe32SQaYLI24/bNzaoyhdBIFY5pVrvMo1ZCvMl8AlfI2OcBXvcGb5aS5z7sCNCJm11UuoYbLI1zw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/url": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.19.4.tgz",
+      "integrity": "sha512-Pa474iBxS+lxsAL4XkETPGIq3EgMLCEb9agj3hAd2VGMTCApaiUvamR4b+uGXIPybN70piFxvzrfoxsG2uIP6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1455,9 +2040,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
       "cpu": [
         "ppc64"
       ],
@@ -1472,9 +2057,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
       "cpu": [
         "arm"
       ],
@@ -1489,9 +2074,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
       "cpu": [
         "arm64"
       ],
@@ -1506,9 +2091,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
       "cpu": [
         "x64"
       ],
@@ -1523,9 +2108,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
       "cpu": [
         "arm64"
       ],
@@ -1540,9 +2125,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
       "cpu": [
         "x64"
       ],
@@ -1557,9 +2142,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
       "cpu": [
         "arm64"
       ],
@@ -1574,9 +2159,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
       "cpu": [
         "x64"
       ],
@@ -1591,9 +2176,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
       "cpu": [
         "arm"
       ],
@@ -1608,9 +2193,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
       "cpu": [
         "arm64"
       ],
@@ -1625,9 +2210,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
       "cpu": [
         "ia32"
       ],
@@ -1642,9 +2227,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
       "cpu": [
         "loong64"
       ],
@@ -1659,9 +2244,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
       "cpu": [
         "mips64el"
       ],
@@ -1676,9 +2261,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
       "cpu": [
         "ppc64"
       ],
@@ -1693,9 +2278,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
       "cpu": [
         "riscv64"
       ],
@@ -1710,9 +2295,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
       "cpu": [
         "s390x"
       ],
@@ -1727,9 +2312,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
       "cpu": [
         "x64"
       ],
@@ -1744,9 +2329,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
       "cpu": [
         "arm64"
       ],
@@ -1761,9 +2346,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
       "cpu": [
         "x64"
       ],
@@ -1778,9 +2363,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
       "cpu": [
         "arm64"
       ],
@@ -1795,9 +2380,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
       "cpu": [
         "x64"
       ],
@@ -1811,10 +2396,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
       "cpu": [
         "x64"
       ],
@@ -1829,9 +2431,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
       "cpu": [
         "arm64"
       ],
@@ -1846,9 +2448,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
       "cpu": [
         "ia32"
       ],
@@ -1863,9 +2465,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
       "cpu": [
         "x64"
       ],
@@ -1940,9 +2542,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2390,9 +2992,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4869,9 +5471,9 @@
       }
     },
     "node_modules/aegir": {
-      "version": "45.0.9",
-      "resolved": "https://registry.npmjs.org/aegir/-/aegir-45.0.9.tgz",
-      "integrity": "sha512-fYJobhH8kVCKrr+N0mraWsmB7LBotf7qxhSGFciRIwXLyh48bu4qpcEVrFN/o4H0X/A+47kAfkQRJbLbDb9uiA==",
+      "version": "45.2.1",
+      "resolved": "https://registry.npmjs.org/aegir/-/aegir-45.2.1.tgz",
+      "integrity": "sha512-3w9s0tOvo2iNW3efMmaFC6hG3uNDt1a/ZN5nTmYUqcpHKH1aw55sLgbmK29+ij/QigGCo8f5xr3nMVOdiI0hmA==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -4901,11 +5503,12 @@
         "chai-subset": "^1.6.0",
         "conventional-changelog-conventionalcommits": "^8.0.0",
         "cors": "^2.8.5",
+        "cspell": "^8.17.5",
         "depcheck": "^1.4.3",
         "diff": "^7.0.0",
         "electron-mocha": "^13.0.0",
         "env-paths": "^3.0.0",
-        "esbuild": "^0.24.0",
+        "esbuild": "^0.25.0",
         "eslint": "^8.31.0",
         "eslint-config-ipfs": "^7.0.0",
         "eslint-plugin-etc": "^2.0.2",
@@ -5235,6 +5838,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -5731,9 +6341,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6323,6 +6933,35 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.2.tgz",
+      "integrity": "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -6427,6 +7066,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/clear-module": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
+      "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^2.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clear-module/node_modules/parent-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+      "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cli-cursor": {
@@ -6810,6 +7479,28 @@
         "node": ">=18"
       }
     },
+    "node_modules/comment-json": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.4.0.tgz",
+      "integrity": "sha512-S/kHITMNFohZ/3lK6zd1Wyxnx+VfjJXzTHSZwUd9kPyNa8ndByPmeZO99MT3k8uFvcgipueyrb6rnefgRiqbAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.3",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/comment-json/node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/comment-parser": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
@@ -7009,23 +7700,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/copy-file": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/copy-file/-/copy-file-11.0.0.tgz",
-      "integrity": "sha512-mFsNh/DIANLqFt5VHZoGirdg7bK5+oTWlhnGu6tgRhzBlnEKWaPX2xrFaLltii/6rmhqFMJqffUgknuRdpYlHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.11",
-        "p-event": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/core-js-compat": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
@@ -7076,27 +7750,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/cpy": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/cpy/-/cpy-11.1.0.tgz",
-      "integrity": "sha512-QGHetPSSuprVs+lJmMDcivvrBwTKASzXQ5qxFvRC2RFESjjod71bDvFvhxTjDgkNjrrb72AI6JPjfYwxrIy33A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "copy-file": "^11.0.0",
-        "globby": "^14.0.2",
-        "junk": "^4.0.1",
-        "micromatch": "^4.0.7",
-        "p-filter": "^4.1.0",
-        "p-map": "^7.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/create-require": {
@@ -7181,6 +7834,253 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cspell": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.19.4.tgz",
+      "integrity": "sha512-toaLrLj3usWY0Bvdi661zMmpKW2DVLAG3tcwkAv4JBTisdIRn15kN/qZDrhSieUEhVgJgZJDH4UKRiq29mIFxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-json-reporter": "8.19.4",
+        "@cspell/cspell-pipe": "8.19.4",
+        "@cspell/cspell-types": "8.19.4",
+        "@cspell/dynamic-import": "8.19.4",
+        "@cspell/url": "8.19.4",
+        "chalk": "^5.4.1",
+        "chalk-template": "^1.1.0",
+        "commander": "^13.1.0",
+        "cspell-dictionary": "8.19.4",
+        "cspell-gitignore": "8.19.4",
+        "cspell-glob": "8.19.4",
+        "cspell-io": "8.19.4",
+        "cspell-lib": "8.19.4",
+        "fast-json-stable-stringify": "^2.1.0",
+        "file-entry-cache": "^9.1.0",
+        "semver": "^7.7.1",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "cspell": "bin.mjs",
+        "cspell-esm": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
+      }
+    },
+    "node_modules/cspell-config-lib": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.19.4.tgz",
+      "integrity": "sha512-LtFNZEWVrnpjiTNgEDsVN05UqhhJ1iA0HnTv4jsascPehlaUYVoyucgNbFeRs6UMaClJnqR0qT9lnPX+KO1OLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-types": "8.19.4",
+        "comment-json": "^4.2.5",
+        "yaml": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-config-lib/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/cspell-dictionary": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.19.4.tgz",
+      "integrity": "sha512-lr8uIm7Wub8ToRXO9f6f7in429P1Egm3I+Ps3ZGfWpwLTCUBnHvJdNF/kQqF7PL0Lw6acXcjVWFYT7l2Wdst2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-pipe": "8.19.4",
+        "@cspell/cspell-types": "8.19.4",
+        "cspell-trie-lib": "8.19.4",
+        "fast-equals": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-gitignore": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.19.4.tgz",
+      "integrity": "sha512-KrViypPilNUHWZkMV0SM8P9EQVIyH8HvUqFscI7+cyzWnlglvzqDdV4N5f+Ax5mK+IqR6rTEX8JZbCwIWWV7og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "8.19.4",
+        "cspell-glob": "8.19.4",
+        "cspell-io": "8.19.4"
+      },
+      "bin": {
+        "cspell-gitignore": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-glob": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.19.4.tgz",
+      "integrity": "sha512-042uDU+RjAz882w+DXKuYxI2rrgVPfRQDYvIQvUrY1hexH4sHbne78+OMlFjjzOCEAgyjnm1ktWUCCmh08pQUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "8.19.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-glob/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/cspell-grammar": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.19.4.tgz",
+      "integrity": "sha512-lzWgZYTu/L7DNOHjxuKf8H7DCXvraHMKxtFObf8bAzgT+aBmey5fW2LviXUkZ2Lb2R0qQY+TJ5VIGoEjNf55ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-pipe": "8.19.4",
+        "@cspell/cspell-types": "8.19.4"
+      },
+      "bin": {
+        "cspell-grammar": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-io": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.19.4.tgz",
+      "integrity": "sha512-W48egJqZ2saEhPWf5ftyighvm4mztxEOi45ILsKgFikXcWFs0H0/hLwqVFeDurgELSzprr12b6dXsr67dV8amg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-service-bus": "8.19.4",
+        "@cspell/url": "8.19.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-lib": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.19.4.tgz",
+      "integrity": "sha512-NwfdCCYtIBNQuZcoMlMmL3HSv2olXNErMi/aOTI9BBAjvCHjhgX5hbHySMZ0NFNynnN+Mlbu5kooJ5asZeB3KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-bundled-dicts": "8.19.4",
+        "@cspell/cspell-pipe": "8.19.4",
+        "@cspell/cspell-resolver": "8.19.4",
+        "@cspell/cspell-types": "8.19.4",
+        "@cspell/dynamic-import": "8.19.4",
+        "@cspell/filetypes": "8.19.4",
+        "@cspell/strong-weak-map": "8.19.4",
+        "@cspell/url": "8.19.4",
+        "clear-module": "^4.1.2",
+        "comment-json": "^4.2.5",
+        "cspell-config-lib": "8.19.4",
+        "cspell-dictionary": "8.19.4",
+        "cspell-glob": "8.19.4",
+        "cspell-grammar": "8.19.4",
+        "cspell-io": "8.19.4",
+        "cspell-trie-lib": "8.19.4",
+        "env-paths": "^3.0.0",
+        "fast-equals": "^5.2.2",
+        "gensequence": "^7.0.0",
+        "import-fresh": "^3.3.1",
+        "resolve-from": "^5.0.0",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-uri": "^3.1.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell-trie-lib": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.19.4.tgz",
+      "integrity": "sha512-yIPlmGSP3tT3j8Nmu+7CNpkPh/gBO2ovdnqNmZV+LNtQmVxqFd2fH7XvR1TKjQyctSH1ip0P5uIdJmzY1uhaYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-pipe": "8.19.4",
+        "@cspell/cspell-types": "8.19.4",
+        "gensequence": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cspell/node_modules/file-entry-cache": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.1.0.tgz",
+      "integrity": "sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cspell/node_modules/flat-cache": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
+      "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.3.1",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/cycle": {
@@ -7536,9 +8436,9 @@
       }
     },
     "node_modules/del/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8471,9 +9371,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -8484,31 +9384,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.24.2",
-        "@esbuild/android-arm": "0.24.2",
-        "@esbuild/android-arm64": "0.24.2",
-        "@esbuild/android-x64": "0.24.2",
-        "@esbuild/darwin-arm64": "0.24.2",
-        "@esbuild/darwin-x64": "0.24.2",
-        "@esbuild/freebsd-arm64": "0.24.2",
-        "@esbuild/freebsd-x64": "0.24.2",
-        "@esbuild/linux-arm": "0.24.2",
-        "@esbuild/linux-arm64": "0.24.2",
-        "@esbuild/linux-ia32": "0.24.2",
-        "@esbuild/linux-loong64": "0.24.2",
-        "@esbuild/linux-mips64el": "0.24.2",
-        "@esbuild/linux-ppc64": "0.24.2",
-        "@esbuild/linux-riscv64": "0.24.2",
-        "@esbuild/linux-s390x": "0.24.2",
-        "@esbuild/linux-x64": "0.24.2",
-        "@esbuild/netbsd-arm64": "0.24.2",
-        "@esbuild/netbsd-x64": "0.24.2",
-        "@esbuild/openbsd-arm64": "0.24.2",
-        "@esbuild/openbsd-x64": "0.24.2",
-        "@esbuild/sunos-x64": "0.24.2",
-        "@esbuild/win32-arm64": "0.24.2",
-        "@esbuild/win32-ia32": "0.24.2",
-        "@esbuild/win32-x64": "0.24.2"
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/esbuild-plugin-wasm": {
@@ -8868,9 +9769,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9012,9 +9913,9 @@
       }
     },
     "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -9100,9 +10001,9 @@
       }
     },
     "node_modules/eslint-plugin-node/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9213,9 +10114,9 @@
       "license": "Python-2.0"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9645,6 +10546,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.3.2.tgz",
+      "integrity": "sha512-6rxyATwPCkaFIL3JLqw8qXqMpIZ942pTX/tbQFkRsDGblS8tNGtlUauA/+mt6RUfqn/4MoEr+WDkYoIQbibWuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -9959,9 +10870,9 @@
       }
     },
     "node_modules/flat-cache/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10276,6 +11187,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensequence": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-7.0.0.tgz",
+      "integrity": "sha512-47Frx13aZh01afHJTB3zTtKIlFI6vWY+MYCN9Qpew6i52rfKjnhCF/l1YlC8UmEMvvntZZ6z4PiCcmyuedR2aQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -10562,6 +11483,32 @@
       },
       "engines": {
         "node": ">=10.0"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/global-modules": {
@@ -12488,9 +13435,9 @@
       }
     },
     "node_modules/istanbul-lib-processinfo/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13091,19 +14038,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/junk": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
-      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/just-extend": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
@@ -13175,9 +14109,9 @@
       }
     },
     "node_modules/kubo": {
-      "version": "0.38.0-rc1",
-      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.38.0-rc1.tgz",
-      "integrity": "sha512-xgMCG6TDj51E5iVXHnor1sn97UbM8yBUnHVUBXYkyb6aqa7ZKt65LYUSxL8dkwAhoNsZNJSqaVZOCVoLsIzgkw==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.38.0.tgz",
+      "integrity": "sha512-J3LEMvAx8VJkyZspsHc9JIIwP/ZtDsR2lDnPboctFZHxt3+cdaEX5Rs7CKMe76Peyjd6Uz0qno8O8e/cZ3iPYg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -13195,9 +14129,9 @@
       }
     },
     "node_modules/kubo-rpc-client": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/kubo-rpc-client/-/kubo-rpc-client-5.0.2.tgz",
-      "integrity": "sha512-0w8VUwpxtkynLlJsAnM+es3qR6Nvv0/oqg0I+sCgI65rh8OPoBYpsk58/miD+u/OkIhJKBwslfeJ9y7Ujb40+g==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/kubo-rpc-client/-/kubo-rpc-client-5.3.0.tgz",
+      "integrity": "sha512-uky2WMSpXxA+GMNLOBLmpR5W7kSMvwCh72FKjz2PNhrB5frHiXboJbYhFewAJ9N0FNnC2E7VUerGqBDAfLSrQg==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
@@ -13209,7 +14143,7 @@
         "@libp2p/logger": "^5.0.0",
         "@libp2p/peer-id": "^5.0.0",
         "@multiformats/multiaddr": "^12.2.1",
-        "@multiformats/multiaddr-to-uri": "^10.0.1",
+        "@multiformats/multiaddr-to-uri": "^11.0.0",
         "any-signal": "^4.1.1",
         "blob-to-it": "^2.0.5",
         "browser-readablestream-to-it": "^2.0.5",
@@ -13229,29 +14163,12 @@
         "multiformats": "^13.1.0",
         "nanoid": "^5.0.7",
         "native-fetch": "^4.0.2",
-        "parse-duration": "^1.0.2",
+        "parse-duration": "^2.1.2",
         "react-native-fetch-api": "^3.0.0",
         "stream-to-it": "^1.0.1",
         "uint8arrays": "^5.0.3",
         "wherearewe": "^2.0.1"
       }
-    },
-    "node_modules/kubo-rpc-client/node_modules/@multiformats/multiaddr-to-uri": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-10.1.2.tgz",
-      "integrity": "sha512-6sicfYRjJlHJn4bwsQancs8kXncWU4dDN/+V9sMVTYp9hi8ovWgVkK75AbAv4SfhztmmI+oufVUncQ1n+SukKQ==",
-      "dev": true,
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@multiformats/multiaddr": "^12.3.0"
-      }
-    },
-    "node_modules/kubo-rpc-client/node_modules/parse-duration": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.2.tgz",
-      "integrity": "sha512-p8EIONG8L0u7f8GFgfVlL4n8rnChTt8O5FSxgxMz2tjc9FMP199wxVKVB6IbKx11uTbKHACSvaLVIKNnoeNR/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/kuler": {
       "version": "2.0.0",
@@ -15639,9 +16556,9 @@
       }
     },
     "node_modules/multimatch/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19159,9 +20076,9 @@
       }
     },
     "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19592,9 +20509,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20299,9 +21216,9 @@
       }
     },
     "node_modules/patch-package/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20861,9 +21778,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
-      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -20874,9 +21791,9 @@
       }
     },
     "node_modules/playwright-test": {
-      "version": "14.1.9",
-      "resolved": "https://registry.npmjs.org/playwright-test/-/playwright-test-14.1.9.tgz",
-      "integrity": "sha512-L6HkKrcaW+qhaIPPOsoR1HDDR3bQdKeQCcpLkCbebZDG1ikSzMwmF3HAcEtAUXbmRwZcvB1dPoxQi6jlCF/f+A==",
+      "version": "14.1.12",
+      "resolved": "https://registry.npmjs.org/playwright-test/-/playwright-test-14.1.12.tgz",
+      "integrity": "sha512-tEhyXJwIU2f5nK9lNKbKBQ8cuBnux69cfm+tjwGGn3wLQkmMa8IfqCGDV5+s2aVrAPvrxlxSDP1cMr6jX8nhsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20885,14 +21802,12 @@
         "buffer": "^6.0.3",
         "c8": "^10.1.3",
         "camelcase": "^8.0.0",
-        "chokidar": "^3.6.0",
-        "cpy": "^11.0.0",
-        "esbuild": "0.23.0",
+        "chokidar": "^4.0.3",
+        "esbuild": "0.25.8",
         "esbuild-plugin-wasm": "^1.1.0",
         "events": "^3.3.0",
         "execa": "^9.3.0",
         "exit-hook": "^4.0.0",
-        "globby": "^14.0.2",
         "kleur": "^4.1.5",
         "lilconfig": "^3.1.3",
         "lodash": "^4.17.21",
@@ -20901,7 +21816,7 @@
         "ora": "^8.0.1",
         "p-timeout": "^6.1.4",
         "path-browserify": "^1.0.1",
-        "playwright-core": "1.50.1",
+        "playwright-core": "1.54.1",
         "polka": "^0.5.2",
         "premove": "^4.0.0",
         "process": "^0.11.10",
@@ -20912,6 +21827,7 @@
         "stream-browserify": "^3.0.0",
         "tempy": "^3.1.0",
         "test-exclude": "^7.0.1",
+        "tinyglobby": "^0.2.14",
         "util": "^0.12.5",
         "v8-to-istanbul": "^9.3.0"
       },
@@ -20924,9 +21840,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.0.tgz",
-      "integrity": "sha512-3sG8Zwa5fMcA9bgqB8AfWPQ+HFke6uD3h1s3RIwUNK8EG7a4buxvuFTs3j1IMs2NXAk9F30C/FF4vxRgQCcmoQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
+      "integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
       "cpu": [
         "ppc64"
       ],
@@ -20941,9 +21857,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/android-arm": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.0.tgz",
-      "integrity": "sha512-+KuOHTKKyIKgEEqKbGTK8W7mPp+hKinbMBeEnNzjJGyFcWsfrXjSTNluJHCY1RqhxFurdD8uNXQDei7qDlR6+g==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
+      "integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
       "cpu": [
         "arm"
       ],
@@ -20958,9 +21874,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/android-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.0.tgz",
-      "integrity": "sha512-EuHFUYkAVfU4qBdyivULuu03FhJO4IJN9PGuABGrFy4vUuzk91P2d+npxHcFdpUnfYKy0PuV+n6bKIpHOB3prQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
+      "integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
       "cpu": [
         "arm64"
       ],
@@ -20975,9 +21891,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/android-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.0.tgz",
-      "integrity": "sha512-WRrmKidLoKDl56LsbBMhzTTBxrsVwTKdNbKDalbEZr0tcsBgCLbEtoNthOW6PX942YiYq8HzEnb4yWQMLQuipQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
+      "integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
       "cpu": [
         "x64"
       ],
@@ -20992,9 +21908,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
-      "integrity": "sha512-YLntie/IdS31H54Ogdn+v50NuoWF5BDkEUFpiOChVa9UnKpftgwzZRrI4J132ETIi+D8n6xh9IviFV3eXdxfow==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
+      "integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
       "cpu": [
         "arm64"
       ],
@@ -21009,9 +21925,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/darwin-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.0.tgz",
-      "integrity": "sha512-IMQ6eme4AfznElesHUPDZ+teuGwoRmVuuixu7sv92ZkdQcPbsNHzutd+rAfaBKo8YK3IrBEi9SLLKWJdEvJniQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
+      "integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
       "cpu": [
         "x64"
       ],
@@ -21026,9 +21942,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.0.tgz",
-      "integrity": "sha512-0muYWCng5vqaxobq6LB3YNtevDFSAZGlgtLoAc81PjUfiFz36n4KMpwhtAd4he8ToSI3TGyuhyx5xmiWNYZFyw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
       "cpu": [
         "arm64"
       ],
@@ -21043,9 +21959,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.0.tgz",
-      "integrity": "sha512-XKDVu8IsD0/q3foBzsXGt/KjD/yTKBCIwOHE1XwiXmrRwrX6Hbnd5Eqn/WvDekddK21tfszBSrE/WMaZh+1buQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
+      "integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
       "cpu": [
         "x64"
       ],
@@ -21060,9 +21976,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/linux-arm": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.0.tgz",
-      "integrity": "sha512-SEELSTEtOFu5LPykzA395Mc+54RMg1EUgXP+iw2SJ72+ooMwVsgfuwXo5Fn0wXNgWZsTVHwY2cg4Vi/bOD88qw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
+      "integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
       "cpu": [
         "arm"
       ],
@@ -21077,9 +21993,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/linux-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.0.tgz",
-      "integrity": "sha512-j1t5iG8jE7BhonbsEg5d9qOYcVZv/Rv6tghaXM/Ug9xahM0nX/H2gfu6X6z11QRTMT6+aywOMA8TDkhPo8aCGw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
+      "integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
       "cpu": [
         "arm64"
       ],
@@ -21094,9 +22010,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/linux-ia32": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.0.tgz",
-      "integrity": "sha512-P7O5Tkh2NbgIm2R6x1zGJJsnacDzTFcRWZyTTMgFdVit6E98LTxO+v8LCCLWRvPrjdzXHx9FEOA8oAZPyApWUA==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
+      "integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
       "cpu": [
         "ia32"
       ],
@@ -21111,9 +22027,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/linux-loong64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.0.tgz",
-      "integrity": "sha512-InQwepswq6urikQiIC/kkx412fqUZudBO4SYKu0N+tGhXRWUqAx+Q+341tFV6QdBifpjYgUndV1hhMq3WeJi7A==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
+      "integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
       "cpu": [
         "loong64"
       ],
@@ -21128,9 +22044,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.0.tgz",
-      "integrity": "sha512-J9rflLtqdYrxHv2FqXE2i1ELgNjT+JFURt/uDMoPQLcjWQA5wDKgQA4t/dTqGa88ZVECKaD0TctwsUfHbVoi4w==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
+      "integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
       "cpu": [
         "mips64el"
       ],
@@ -21145,9 +22061,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.0.tgz",
-      "integrity": "sha512-cShCXtEOVc5GxU0fM+dsFD10qZ5UpcQ8AM22bYj0u/yaAykWnqXJDpd77ublcX6vdDsWLuweeuSNZk4yUxZwtw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
+      "integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
       "cpu": [
         "ppc64"
       ],
@@ -21162,9 +22078,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.0.tgz",
-      "integrity": "sha512-HEtaN7Y5UB4tZPeQmgz/UhzoEyYftbMXrBCUjINGjh3uil+rB/QzzpMshz3cNUxqXN7Vr93zzVtpIDL99t9aRw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
+      "integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
       "cpu": [
         "riscv64"
       ],
@@ -21179,9 +22095,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/linux-s390x": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.0.tgz",
-      "integrity": "sha512-WDi3+NVAuyjg/Wxi+o5KPqRbZY0QhI9TjrEEm+8dmpY9Xir8+HE/HNx2JoLckhKbFopW0RdO2D72w8trZOV+Wg==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
+      "integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
       "cpu": [
         "s390x"
       ],
@@ -21196,9 +22112,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/linux-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.0.tgz",
-      "integrity": "sha512-a3pMQhUEJkITgAw6e0bWA+F+vFtCciMjW/LPtoj99MhVt+Mfb6bbL9hu2wmTZgNd994qTAEw+U/r6k3qHWWaOQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
+      "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
       "cpu": [
         "x64"
       ],
@@ -21212,10 +22128,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/playwright-test/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/playwright-test/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.0.tgz",
-      "integrity": "sha512-cRK+YDem7lFTs2Q5nEv/HHc4LnrfBCbH5+JHu6wm2eP+d8OZNoSMYgPZJq78vqQ9g+9+nMuIsAO7skzphRXHyw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
       "cpu": [
         "x64"
       ],
@@ -21230,9 +22163,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.0.tgz",
-      "integrity": "sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
       "cpu": [
         "arm64"
       ],
@@ -21247,9 +22180,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.0.tgz",
-      "integrity": "sha512-6p3nHpby0DM/v15IFKMjAaayFhqnXV52aEmv1whZHX56pdkK+MEaLoQWj+H42ssFarP1PcomVhbsR4pkz09qBg==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
       "cpu": [
         "x64"
       ],
@@ -21263,10 +22196,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/playwright-test/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
+      "integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/playwright-test/node_modules/@esbuild/sunos-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.0.tgz",
-      "integrity": "sha512-BFelBGfrBwk6LVrmFzCq1u1dZbG4zy/Kp93w2+y83Q5UGYF1d8sCzeLI9NXjKyujjBBniQa8R8PzLFAUrSM9OA==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
+      "integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
       "cpu": [
         "x64"
       ],
@@ -21281,9 +22231,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/win32-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.0.tgz",
-      "integrity": "sha512-lY6AC8p4Cnb7xYHuIxQ6iYPe6MfO2CC43XXKo9nBXDb35krYt7KGhQnOkRGar5psxYkircpCqfbNDB4uJbS2jQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
+      "integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
       "cpu": [
         "arm64"
       ],
@@ -21298,9 +22248,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/win32-ia32": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.0.tgz",
-      "integrity": "sha512-7L1bHlOTcO4ByvI7OXVI5pNN6HSu6pUQq9yodga8izeuB1KcT2UkHaH6118QJwopExPn0rMHIseCTx1CRo/uNA==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
+      "integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
       "cpu": [
         "ia32"
       ],
@@ -21315,9 +22265,9 @@
       }
     },
     "node_modules/playwright-test/node_modules/@esbuild/win32-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.0.tgz",
-      "integrity": "sha512-Arm+WgUFLUATuoxCJcahGuk6Yj9Pzxd6l11Zb/2aAuv5kWWvvfhLFo2fni4uSK5vzlUdCGZ/BdV5tH8klj8p8g==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
+      "integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
       "cpu": [
         "x64"
       ],
@@ -21357,10 +22307,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/playwright-test/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/playwright-test/node_modules/esbuild": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.0.tgz",
-      "integrity": "sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
+      "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -21371,30 +22337,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.23.0",
-        "@esbuild/android-arm": "0.23.0",
-        "@esbuild/android-arm64": "0.23.0",
-        "@esbuild/android-x64": "0.23.0",
-        "@esbuild/darwin-arm64": "0.23.0",
-        "@esbuild/darwin-x64": "0.23.0",
-        "@esbuild/freebsd-arm64": "0.23.0",
-        "@esbuild/freebsd-x64": "0.23.0",
-        "@esbuild/linux-arm": "0.23.0",
-        "@esbuild/linux-arm64": "0.23.0",
-        "@esbuild/linux-ia32": "0.23.0",
-        "@esbuild/linux-loong64": "0.23.0",
-        "@esbuild/linux-mips64el": "0.23.0",
-        "@esbuild/linux-ppc64": "0.23.0",
-        "@esbuild/linux-riscv64": "0.23.0",
-        "@esbuild/linux-s390x": "0.23.0",
-        "@esbuild/linux-x64": "0.23.0",
-        "@esbuild/netbsd-x64": "0.23.0",
-        "@esbuild/openbsd-arm64": "0.23.0",
-        "@esbuild/openbsd-x64": "0.23.0",
-        "@esbuild/sunos-x64": "0.23.0",
-        "@esbuild/win32-arm64": "0.23.0",
-        "@esbuild/win32-ia32": "0.23.0",
-        "@esbuild/win32-x64": "0.23.0"
+        "@esbuild/aix-ppc64": "0.25.8",
+        "@esbuild/android-arm": "0.25.8",
+        "@esbuild/android-arm64": "0.25.8",
+        "@esbuild/android-x64": "0.25.8",
+        "@esbuild/darwin-arm64": "0.25.8",
+        "@esbuild/darwin-x64": "0.25.8",
+        "@esbuild/freebsd-arm64": "0.25.8",
+        "@esbuild/freebsd-x64": "0.25.8",
+        "@esbuild/linux-arm": "0.25.8",
+        "@esbuild/linux-arm64": "0.25.8",
+        "@esbuild/linux-ia32": "0.25.8",
+        "@esbuild/linux-loong64": "0.25.8",
+        "@esbuild/linux-mips64el": "0.25.8",
+        "@esbuild/linux-ppc64": "0.25.8",
+        "@esbuild/linux-riscv64": "0.25.8",
+        "@esbuild/linux-s390x": "0.25.8",
+        "@esbuild/linux-x64": "0.25.8",
+        "@esbuild/netbsd-arm64": "0.25.8",
+        "@esbuild/netbsd-x64": "0.25.8",
+        "@esbuild/openbsd-arm64": "0.25.8",
+        "@esbuild/openbsd-x64": "0.25.8",
+        "@esbuild/openharmony-arm64": "0.25.8",
+        "@esbuild/sunos-x64": "0.25.8",
+        "@esbuild/win32-arm64": "0.25.8",
+        "@esbuild/win32-ia32": "0.25.8",
+        "@esbuild/win32-x64": "0.25.8"
       }
     },
     "node_modules/playwright-test/node_modules/execa": {
@@ -21508,6 +22476,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright-test/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/playwright-test/node_modules/strip-final-newline": {
@@ -23004,13 +23986,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -25074,9 +26049,9 @@
       }
     },
     "node_modules/spawn-wrap/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25789,9 +26764,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26050,6 +27025,54 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmp": {
@@ -26950,9 +27973,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.3.0.tgz",
-      "integrity": "sha512-Qy96NND4Dou5jKoSJ2gm8ax8AJM/Ey9o9mz7KN1bb9GP+G0l20Zw8afxTnY2f4b7hmhn/z8aC2kfArVQlAhFBw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -27348,6 +28371,13 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
@@ -27359,6 +28389,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
       "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -27835,6 +28872,19 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "it-pipe": "^3.0.1",
     "it-tar": "^6.0.0",
     "it-to-buffer": "^4.0.5",
-    "kubo": "^0.29.0",
+    "kubo": "^0.37.0",
     "mock-ipfs-pinning-service": "^0.4.2",
     "nock": "^14.0.1",
     "p-defer": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "it-pipe": "^3.0.1",
     "it-tar": "^6.0.0",
     "it-to-buffer": "^4.0.5",
-    "kubo": "^0.37.0",
+    "kubo": "^0.38.0-rc1",
     "mock-ipfs-pinning-service": "^0.4.2",
     "nock": "^14.0.1",
     "p-defer": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "it-pipe": "^3.0.1",
     "it-tar": "^6.0.0",
     "it-to-buffer": "^4.0.5",
-    "kubo": "^0.38.0-rc1",
+    "kubo": "^0.38.0",
     "mock-ipfs-pinning-service": "^0.4.2",
     "nock": "^14.0.1",
     "p-defer": "^4.0.0",

--- a/src/bitswap/stat.ts
+++ b/src/bitswap/stat.ts
@@ -18,7 +18,7 @@ export function createStat (client: HTTPRPCClient): BitswapAPI['stat'] {
 
 function toCoreInterface (res: any): BitswapStats {
   return {
-    provideBufLen: res.ProvideBufLen,
+    provideBufLen: res.ProvideBufLen ?? 0,
     wantlist: (res.Wantlist ?? []).map((k: any) => CID.parse(k['/'])),
     peers: (res.Peers ?? []).map((str: any) => peerIdFromString(str)),
     blocksReceived: BigInt(res.BlocksReceived),

--- a/src/lib/to-url-search-params.ts
+++ b/src/lib/to-url-search-params.ts
@@ -35,7 +35,15 @@ export function toUrlSearchParams ({ arg, searchParams, hashAlg, mtime, mode, ..
     arg = [arg]
   }
 
-  const urlSearchParams = new URLSearchParams(options)
+  // Filter out undefined and null values to avoid sending "undefined" or "null" as strings
+  const filteredOptions: Record<string, any> = {}
+  for (const [key, value] of Object.entries(options)) {
+    if (value !== undefined && value !== null) {
+      filteredOptions[key] = value
+    }
+  }
+
+  const urlSearchParams = new URLSearchParams(filteredOptions)
 
   arg.forEach((arg: any) => {
     urlSearchParams.append('arg', arg)

--- a/src/pin/add-all.ts
+++ b/src/pin/add-all.ts
@@ -6,14 +6,15 @@ import type { HTTPRPCClient } from '../lib/core.js'
 
 export function createAddAll (client: HTTPRPCClient): PinAPI['addAll'] {
   return async function * addAll (source, options = {}) {
-    for await (const { path, recursive, metadata } of normaliseInput(source)) {
+    for await (const { path, recursive, metadata, name } of normaliseInput(source)) {
       const res = await client.post('pin/add', {
         signal: options.signal,
         searchParams: toUrlSearchParams({
           ...options,
-          arg: path,
+          arg: path.toString(),
           recursive,
           metadata: metadata != null ? JSON.stringify(metadata) : undefined,
+          name: name ?? options.name,
           stream: true
         }),
         headers: options.headers

--- a/src/pin/index.ts
+++ b/src/pin/index.ts
@@ -41,6 +41,11 @@ export interface PinAddAllOptions extends HTTPRPCOptions {
    * Internal option used to control whether to create a repo write lock during a pinning operation
    */
   lock?: boolean
+
+  /**
+   * An optional name for created pin(s)
+   */
+  name?: string
 }
 
 export type PinAddInput = CID | PinAddInputWithOptions
@@ -65,6 +70,11 @@ export interface PinAddInputWithOptions {
    * A human readable string to store with this pin
    */
   comments?: string
+
+  /**
+   * An optional name for the created pin
+   */
+  name?: string
 }
 
 export type PinType = 'recursive' | 'direct' | 'indirect' | 'all'
@@ -72,9 +82,30 @@ export type PinType = 'recursive' | 'direct' | 'indirect' | 'all'
 export type PinQueryType = 'recursive' | 'direct' | 'indirect' | 'all'
 
 export interface PinLsOptions extends HTTPRPCOptions {
+  /**
+   * Path(s) to specific object(s) to be listed
+   */
   paths?: CID | CID[] | string | string[]
+
+  /**
+   * The type of pinned keys to list. Can be "direct", "indirect", "recursive", or "all".
+   *
+   * @default "all"
+   */
   type?: PinQueryType
+
+  /**
+   * Limit returned pins to ones with names that contain the value provided (case-sensitive, partial match).
+   * Implies names=true.
+   */
   name?: string
+
+  /**
+   * Include pin names in the output (slower, disabled by default).
+   *
+   * @default false
+   */
+  names?: boolean
 }
 
 export interface PinLsResult {

--- a/src/pin/ls.ts
+++ b/src/pin/ls.ts
@@ -27,11 +27,25 @@ export function createLs (client: HTTPRPCClient): PinAPI['ls'] {
       paths = Array.isArray(options.paths) ? options.paths : [options.paths]
     }
 
+    // Check for conflicting options
+    if (options.name != null && options.names === false) {
+      throw new Error('Cannot use name filter when names is explicitly set to false')
+    }
+
+    // Check for empty name filter
+    if (options.name === '') {
+      throw new Error('Name filter cannot be empty string')
+    }
+
+    // If name filter is provided, automatically enable names flag
+    const names = options.names ?? (options.name != null)
+
     const res = await client.post('pin/ls', {
       signal: options.signal,
       searchParams: toUrlSearchParams({
         ...options,
         arg: paths.map(path => `${path}`),
+        names,
         stream: true
       }),
       headers: options.headers

--- a/test/files.spec.ts
+++ b/test/files.spec.ts
@@ -2,8 +2,8 @@
 
 import * as dagPB from '@ipld/dag-pb'
 import { expect } from 'aegir/chai'
-import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { UnixFS } from 'ipfs-unixfs'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { factory } from './utils/factory.js'
 import type { KuboRPCClient } from '../src/index.js'
 

--- a/test/files.spec.ts
+++ b/test/files.spec.ts
@@ -3,6 +3,7 @@
 import * as dagPB from '@ipld/dag-pb'
 import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { UnixFS } from 'ipfs-unixfs'
 import { factory } from './utils/factory.js'
 import type { KuboRPCClient } from '../src/index.js'
 
@@ -19,23 +20,35 @@ describe('.add', function () {
 
   after(async function () { return f.clean() })
 
-  it('should ignore metadata until https://github.com/ipfs/go-ipfs/issues/6920 is implemented', async function () {
+  it('should send metadata when provided (affects CID) but not return it until issue #6920 is resolved', async function () {
     const data = uint8ArrayFromString('some data')
     const result = await ipfs.add(data, {
       // @ts-expect-error missing field
       mode: 0o600,
       mtime: {
         secs: 1000,
-        nsecs: 0
+        nsecs: 500
       }
     })
 
+    // Metadata is not returned in response yet (issue #6920)
     expect(result).to.not.have.property('mode')
     expect(result).to.not.have.property('mtime')
     expect(result).to.have.property('cid')
 
     const { cid } = result
     expect(cid).to.have.property('code', dagPB.code)
-    expect(cid.toString()).to.equal('QmVv4Wz46JaZJeH5PMV4LGbRiiMKEmszPYY3g6fjGnVXBS')
+    // CID is different because metadata is now properly sent to the API
+    expect(cid.toString()).to.equal('QmPDB1sHH2FNqwJm2A6747uf6JUZyEB2cnNFRPz2uzjoDZ')
+
+    // Verify metadata is stored in UnixFS structure via DAG API
+    const dagNode = await ipfs.dag.get(cid)
+    const pbData = dagNode.value.Data
+    const unixfs = UnixFS.unmarshal(pbData)
+
+    // Verify mode and mtime are stored
+    expect(unixfs.mode).to.equal(0o600)
+    expect(unixfs.mtime?.secs).to.equal(1000n)
+    expect(unixfs.mtime?.nsecs).to.equal(500)
   })
 })

--- a/test/interface-tests.spec.ts
+++ b/test/interface-tests.spec.ts
@@ -267,7 +267,7 @@ describe('kubo-rpc-client tests against kubo', function () {
      */
     const commonFactory = factory({
       type: 'kubo',
-      bin: kubo?.path(),
+      bin: process.env.IPFS_GO_EXEC ?? kubo?.path(),
       test: true
     })
     describe('kubo RPC client interface tests', function () {

--- a/test/interface-tests.spec.ts
+++ b/test/interface-tests.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { path } from 'kubo'
+import kubo from 'kubo'
 import { isWindows, isFirefox, isChrome } from './constants.js'
 import * as tests from './interface-tests/src/index.js'
 import { factory } from './utils/factory.js'
@@ -267,7 +267,7 @@ describe('kubo-rpc-client tests against kubo', function () {
      */
     const commonFactory = factory({
       type: 'kubo',
-      bin: path?.(),
+      bin: kubo?.path(),
       test: true
     })
     describe('kubo RPC client interface tests', function () {

--- a/test/interface-tests/src/config/set.ts
+++ b/test/interface-tests/src/config/set.ts
@@ -23,21 +23,21 @@ export function testSet (factory: Factory<KuboNode>, options: MochaConfig): void
     })
 
     it('should set a new key', async () => {
-      await ipfs.config.set('Fruit', 'banana')
+      await ipfs.config.set('Gateway.RootRedirect', '/test1')
 
-      const fruit = await ipfs.config.get('Fruit')
-      expect(fruit).to.equal('banana')
+      const redirect = await ipfs.config.get('Gateway.RootRedirect')
+      expect(redirect).to.equal('/test1')
     })
 
     it('should set an already existing key', async () => {
-      await ipfs.config.set('Fruit', 'morango')
+      await ipfs.config.set('Gateway.RootRedirect', '/test2')
 
-      const fruit = await ipfs.config.get('Fruit')
-      expect(fruit).to.equal('morango')
+      const redirect = await ipfs.config.get('Gateway.RootRedirect')
+      expect(redirect).to.equal('/test2')
     })
 
     it('should set a number', async () => {
-      const key = 'Discovery.MDNS.Interval'
+      const key = 'Gateway.MaxConcurrentRequests'
       const val = 11
 
       await ipfs.config.set(key, val)
@@ -77,10 +77,15 @@ export function testSet (factory: Factory<KuboNode>, options: MochaConfig): void
       return expect(ipfs.config.set(uint8ArrayFromString('heeey'), '')).to.eventually.be.rejected()
     })
 
+    it('should fail on unknown config key', () => {
+      return expect(ipfs.config.set('Fruit', 'banana')).to.eventually.be.rejected()
+        .with.property('message').that.matches(/Fruit not found/)
+    })
+
     it('should fail on non valid value', () => {
       const val: any = {}
       val.val = val
-      return expect(ipfs.config.set('Fruit', val)).to.eventually.be.rejected()
+      return expect(ipfs.config.set('Gateway.RootRedirect', val)).to.eventually.be.rejected()
     })
   })
 }

--- a/test/interface-tests/src/miscellaneous/version.ts
+++ b/test/interface-tests/src/miscellaneous/version.ts
@@ -22,7 +22,6 @@ export function testVersion (factory: Factory<KuboNode>, options: MochaConfig): 
 
     it('should get the node version', async () => {
       const result = await ipfs.version()
-      console.log('IPFS version:', result.version, 'commit:', result.commit)
       expect(result).to.have.a.property('version')
       expect(result).to.have.a.property('commit')
       expect(result).to.have.a.property('repo')

--- a/test/interface-tests/src/miscellaneous/version.ts
+++ b/test/interface-tests/src/miscellaneous/version.ts
@@ -22,6 +22,7 @@ export function testVersion (factory: Factory<KuboNode>, options: MochaConfig): 
 
     it('should get the node version', async () => {
       const result = await ipfs.version()
+      console.log('IPFS version:', result.version, 'commit:', result.commit)
       expect(result).to.have.a.property('version')
       expect(result).to.have.a.property('commit')
       expect(result).to.have.a.property('repo')

--- a/test/interface-tests/src/pin/add.ts
+++ b/test/interface-tests/src/pin/add.ts
@@ -177,5 +177,63 @@ export function testAdd (factory: Factory<KuboNode>, options: MochaConfig): void
         type: 'indirect'
       })
     })
+
+    it('should add a pin with a name', async () => {
+      const pinName = 'test-pin-name'
+      const cid = await ipfs.pin.add(fixtures.files[0].cid, {
+        name: pinName
+      })
+      expect(cid).to.deep.equal(fixtures.files[0].cid)
+
+      // Using name filter automatically enables names flag
+      const pins = await all(ipfs.pin.ls({ name: pinName }))
+      expect(pins).to.have.lengthOf(1)
+      expect(pins[0]).to.deep.include({
+        cid: fixtures.files[0].cid,
+        type: 'recursive',
+        name: pinName
+      })
+    })
+
+    it('should add a pin without a name', async () => {
+      const cid = await ipfs.pin.add(fixtures.files[0].cid)
+      expect(cid).to.deep.equal(fixtures.files[0].cid)
+
+      // Check without names flag - name should be undefined
+      const pins = await all(ipfs.pin.ls({ paths: fixtures.files[0].cid }))
+      expect(pins).to.have.lengthOf(1)
+      expect(pins[0].cid).to.deep.equal(fixtures.files[0].cid)
+      expect(pins[0].name).to.be.undefined()
+
+      // Also verify with names flag - should still be undefined since no name was set
+      const pinsWithNames = await all(ipfs.pin.ls({ paths: fixtures.files[0].cid, names: true }))
+      expect(pinsWithNames).to.have.lengthOf(1)
+      expect(pinsWithNames[0].cid).to.deep.equal(fixtures.files[0].cid)
+      expect(pinsWithNames[0].name).to.be.undefined()
+    })
+
+    it('should update pin name when pinning again with different name', async () => {
+      const firstName = 'first-name'
+      const secondName = 'second-name'
+
+      // Pin with first name
+      await ipfs.pin.add(fixtures.files[0].cid, { name: firstName })
+
+      // Verify first name (name filter automatically enables names flag)
+      let pins = await all(ipfs.pin.ls({ name: firstName }))
+      expect(pins).to.have.lengthOf(1)
+      expect(pins[0].name).to.equal(firstName)
+
+      // Pin again with second name
+      await ipfs.pin.add(fixtures.files[0].cid, { name: secondName })
+
+      // Verify name was updated
+      pins = await all(ipfs.pin.ls({ name: firstName }))
+      expect(pins).to.have.lengthOf(0)
+
+      pins = await all(ipfs.pin.ls({ name: secondName }))
+      expect(pins).to.have.lengthOf(1)
+      expect(pins[0].name).to.equal(secondName)
+    })
   })
 }

--- a/test/interface-tests/src/pin/ls.ts
+++ b/test/interface-tests/src/pin/ls.ts
@@ -194,6 +194,7 @@ export function testLs (factory: Factory<KuboNode>, options: MochaConfig): void 
     })
 
     it('should list specific named pin', async () => {
+      // Using name filter automatically enables names
       const pinset = await all(ipfs.pin.ls({
         name: fixtures.files[0].pinName
       }))
@@ -202,6 +203,69 @@ export function testLs (factory: Factory<KuboNode>, options: MochaConfig): void 
       expect(cids).to.include(fixtures.files[0].cid.toString())
       const names = pinset.map(p => p.name)
       expect(names).to.include(fixtures.files[0].pinName)
+    })
+
+    it('should list pins with names when names flag is true', async () => {
+      const pinset = await all(ipfs.pin.ls({ names: true }))
+
+      // Find pins with names
+      const pinWithName1 = pinset.find(p => p.cid.equals(fixtures.files[0].cid))
+      const pinWithName2 = pinset.find(p => p.cid.equals(fixtures.files[1].cid))
+
+      expect(pinWithName1?.name).to.equal(fixtures.files[0].pinName)
+      expect(pinWithName2?.name).to.equal(fixtures.files[1].pinName)
+
+      // Pins without names should have undefined
+      const pinWithoutName = pinset.find(p => p.cid.equals(fixtures.directory.cid))
+      expect(pinWithoutName?.name).to.be.undefined()
+    })
+
+    it('should not return names when names flag is not set', async () => {
+      const pinset = await all(ipfs.pin.ls())
+
+      // All pins should have undefined names when names flag is not set
+      for (const pin of pinset) {
+        expect(pin.name).to.be.undefined()
+      }
+    })
+
+    it('should throw error when name filter is used with names explicitly false', async () => {
+      await expect(all(ipfs.pin.ls({
+        name: 'test',
+        names: false
+      }))).to.be.rejectedWith(/Cannot use name filter when names is explicitly set to false/)
+    })
+
+    it('should throw error for empty name filter', async () => {
+      await expect(all(ipfs.pin.ls({
+        name: ''
+      }))).to.be.rejectedWith(/Name filter cannot be empty string/)
+    })
+
+    it('should return empty array when name filter has no matches', async () => {
+      const pinset = await all(ipfs.pin.ls({
+        name: 'non-existent-pin-name-that-does-not-match-anything'
+      }))
+      expect(pinset).to.have.lengthOf(0)
+    })
+
+    it('should list pins with names flag for specific paths', async () => {
+      // With names flag - should return the name
+      const pinsWithNames = await all(ipfs.pin.ls({
+        paths: fixtures.files[0].cid,
+        names: true
+      }))
+      expect(pinsWithNames).to.have.lengthOf(1)
+      expect(pinsWithNames[0].cid).to.deep.equal(fixtures.files[0].cid)
+      expect(pinsWithNames[0].name).to.equal(fixtures.files[0].pinName)
+
+      // Without names flag - should not return the name
+      const pinsWithoutNames = await all(ipfs.pin.ls({
+        paths: fixtures.files[0].cid
+      }))
+      expect(pinsWithoutNames).to.have.lengthOf(1)
+      expect(pinsWithoutNames[0].cid).to.deep.equal(fixtures.files[0].cid)
+      expect(pinsWithoutNames[0].name).to.be.undefined()
     })
 
     it('should throw error for invalid non-string pin type option', () => {

--- a/test/interface-tests/src/stats/utils.ts
+++ b/test/interface-tests/src/stats/utils.ts
@@ -20,7 +20,7 @@ export function expectIsBitswap (err: Error | null, stats: BitswapStats): void {
   expect(stats).to.have.a.property('dupBlksReceived')
   expect(stats).to.have.a.property('dupDataReceived')
 
-  expect(stats.provideBufLen).to.a('number')
+  expect(stats.provideBufLen).to.a('number') // Defaults to 0 if not provided by API
   expect(stats.wantlist).to.be.an('array')
   expect(stats.peers).to.be.an('array')
   expect(isBigInt(stats.blocksReceived)).to.eql(true)

--- a/test/utils/factory.ts
+++ b/test/utils/factory.ts
@@ -1,5 +1,5 @@
 import { createFactory, type Factory, type KuboNode, type KuboOptions } from 'ipfsd-ctl'
-import { path } from 'kubo'
+import kubo from 'kubo'
 import mergeOpts from 'merge-options'
 import { isNode } from 'wherearewe'
 import { create } from '../../src/index.js'
@@ -11,7 +11,7 @@ const commonOptions: KuboOptions = {
   type: 'kubo',
   rpc: create,
   endpoint: process.env.IPFSD_SERVER,
-  bin: isNode ? (process.env.IPFS_GO_EXEC ?? path()) : undefined
+  bin: isNode ? (process.env.IPFS_GO_EXEC ?? kubo.path()) : undefined
 }
 
 export const factory = (options: any = {}, overrides: any = {}): Factory<KuboNode> => createFactory(


### PR DESCRIPTION
This PR adds proper name support to `kubo-rpc-client` making them usable once Kubo 0.38 ships with necessary fixes

- add name parameter to `pin.add` and `pin.addAll`
- add names flag to `pin.ls` (auto-enabled with name filter)



## TODO
- [x] fix `ipfs pin ls` with `--names` vs `--name`
- [x] test with fix from https://github.com/ipfs/kubo/pull/10966
  - This is still broken, the test still fails. Needs proper fix in Boxo.
  - [x] switch to kubo with https://github.com/ipfs/kubo/pull/10970

