### PR TITLE
feat: implement log/get-level API

### DIFF
--- a/src/log/get-level.ts
+++ b/src/log/get-level.ts
@@ -1,0 +1,19 @@
+import { toUrlSearchParams } from '../lib/to-url-search-params.js'
+import type { LogAPI } from './index.js'
+import type { HTTPRPCClient } from '../lib/core.js'
+
+export function createGetLevel (client: HTTPRPCClient): LogAPI['getLevel'] {
+  return async function getLevel (subsystem = 'all', options = {}) {
+    const res = await client.post('log/level', {
+      signal: options.signal,
+      searchParams: toUrlSearchParams({
+        arg: subsystem,
+        ...options
+      }),
+      headers: options.headers
+    })
+
+    const data = await res.json()
+    return data.Levels
+  }
+}

--- a/src/log/index.ts
+++ b/src/log/index.ts
@@ -1,3 +1,4 @@
+import { createGetLevel } from './get-level.js'
 import { createLevel } from './level.js'
 import { createLs } from './ls.js'
 import { createTail } from './tail.js'
@@ -5,6 +6,7 @@ import type { HTTPRPCOptions } from '../index.js'
 import type { HTTPRPCClient } from '../lib/core.js'
 
 export interface LogAPI {
+  getLevel(subsystem?: string, options?: HTTPRPCOptions): Promise<Record<string, string>>
   level(subsystem: string, level: string, options?: HTTPRPCOptions): Promise<any>
   ls(options?: HTTPRPCOptions): Promise<any>
   tail(options?: HTTPRPCOptions): AsyncIterable<any>
@@ -12,6 +14,7 @@ export interface LogAPI {
 
 export function createLog (client: HTTPRPCClient): LogAPI {
   return {
+    getLevel: createGetLevel(client),
     level: createLevel(client),
     ls: createLs(client),
     tail: createTail(client)

--- a/test/log.spec.ts
+++ b/test/log.spec.ts
@@ -50,4 +50,43 @@ describe('.log', function () {
     expect(res).to.not.have.property('error')
     expect(res).to.have.property('message')
   })
+
+  it('.log.getLevel for all subsystems', async function () {
+    const res = await ipfs.log.getLevel()
+
+    expect(res).to.exist()
+    expect(res).to.be.an('object')
+    // Should have subsystem names as keys with log levels as values
+    const keys = Object.keys(res)
+    expect(keys.length).to.be.greaterThan(0)
+    // All values should be strings (log level names)
+    for (const value of Object.values(res)) {
+      expect(value).to.be.a('string')
+    }
+  })
+
+  it('.log.getLevel for specific subsystem', async function () {
+    const res = await ipfs.log.getLevel('all')
+
+    expect(res).to.exist()
+    expect(res).to.be.an('object')
+    // Should have subsystem names as keys with log levels as values
+    for (const value of Object.values(res)) {
+      expect(value).to.be.a('string')
+    }
+  })
+
+  it('.log.getLevel reflects changes made by .log.level', async function () {
+    // Set level to debug
+    await ipfs.log.level('all', 'debug')
+
+    // Get all levels and verify they are set to debug
+    const levels = await ipfs.log.getLevel()
+
+    expect(levels).to.exist()
+    expect(levels).to.be.an('object')
+    // At least some subsystems should be set to debug
+    const values = Object.values(levels)
+    expect(values).to.include('debug')
+  })
 })


### PR DESCRIPTION
## Summary
- Implements the `log.getLevel()` API to retrieve current log levels without modifying them
- Uses the Kubo `log/level` endpoint with a single arg parameter to query levels
- Adds comprehensive tests for the new functionality

Closes #339

## Test plan
- [x] Run `npm test -- --grep "log"` to verify all log tests pass
- [x] Verify TypeScript builds without errors
- [x] Verify linting passes