### PR TITLE
test(provide_stat): add test for provide.stat()

### DIFF
--- a/test/provide.spec.ts
+++ b/test/provide.spec.ts
@@ -1,0 +1,60 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import { factory } from './utils/factory.js'
+import type { KuboRPCClient } from '../src/index.js'
+
+const f = factory()
+
+describe('.provide', function () {
+  this.timeout(60 * 1000)
+
+  let ipfs: KuboRPCClient
+
+  before(async function () {
+    ipfs = (await f.spawn()).api
+  })
+
+  after(async function () {
+    await f.clean()
+  })
+
+  it('.provide.stat', async function () {
+    const res = await ipfs.provide.stat({ lan: true })
+    expect(res).to.exist()
+
+    if ('FullRT' in res) {
+      expect(res.FullRT).to.be.a('boolean')
+    }
+
+    // Sweep provider 
+    if (res.Sweep) {
+      expect(res.Legacy).to.be.oneOf([null, undefined])
+      expect(res.Sweep).to.have.property('workers')
+      expect(res.Sweep.workers).to.have.property('max')
+      expect(res.Sweep).to.have.property('timing')
+      expect(res.Sweep.timing).to.have.property('reprovides_interval')
+
+      return
+    }
+
+    //  legacy provider
+    if (res.Legacy) {
+      expect(res.Legacy).to.have.property('total_reprovides')
+      return
+    }
+
+    // Flat legacy provider (older kubo output)
+    if ('TotalReprovides' in res) {
+      expect(res).to.have.property('TotalReprovides')
+      expect(res).to.have.property('AvgReprovideDuration')
+      expect(res).to.have.property('LastReprovideDuration')
+      expect(res).to.have.property('ReprovideInterval')
+      return
+    }
+
+    throw new Error(
+      `Unknown provide.stat response shape: ${JSON.stringify(res)}`
+    )
+  })
+})

--- a/test/provide.spec.ts
+++ b/test/provide.spec.ts
@@ -27,7 +27,7 @@ describe('.provide', function () {
       expect(res.FullRT).to.be.a('boolean')
     }
 
-    // Sweep provider 
+    // Sweep provider
     if (res.Sweep) {
       expect(res.Legacy).to.be.oneOf([null, undefined])
       expect(res.Sweep).to.have.property('workers')


### PR DESCRIPTION
This PR adds a basic regression test for the new ipfs.provide.stat RPC endpoint in js-kubo-rpc-client.

The test verifies that the client correctly handles all supported response shapes returned by Kubo. It ensures that mapped fields exposed by the client exist and have valid values when present.

related #359 